### PR TITLE
Bulk create (CreateMultiple), paged retrieves, README/quickstart updates

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import os
+from typing import Optional
 
 # Add src to PYTHONPATH for local runs
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
@@ -10,27 +11,36 @@ from azure.identity import InteractiveBrowserCredential
 import traceback
 import requests
 import time
+from datetime import date, timedelta
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
-if not sys.stdin.isatty():
-	print("Interactive input required for org URL. Run this script in a TTY.")
-	sys.exit(1)
+
 entered = input("Enter Dataverse org URL (e.g. https://yourorg.crm.dynamics.com): ").strip()
 if not entered:
 	print("No URL entered; exiting.")
 	sys.exit(1)
+
 base_url = entered.rstrip('/')
-client = DataverseClient(base_url=base_url, credential=InteractiveBrowserCredential())
+delete_choice = input("Delete the SampleItem table at end? (Y/n): ").strip() or "y"
+delete_table_at_end = (str(delete_choice).lower() in ("y", "yes", "true", "1"))
+# Ask once whether to pause between steps during this run
+pause_choice = input("Pause between test steps? (y/N): ").strip() or "n"
+pause_between_steps = (str(pause_choice).lower() in ("y", "yes", "true", "1"))
+# Create a credential we can reuse (for DataverseClient)
+credential = InteractiveBrowserCredential()
+client = DataverseClient(base_url=base_url, credential=credential)
 
 # Small helpers: call logging and step pauses
 def log_call(call: str) -> None:
 	print({"call": call})
 
 def pause(next_step: str) -> None:
-	# No-op (env-free quickstart)
-	return
-
-def plan_call(call: str) -> None:
-	print({"plan": call})
+	if pause_between_steps:
+		try:
+			input(f"\nNext: {next_step} — press Enter to continue...")
+		except EOFError:
+			# If stdin is not available, just proceed
+			pass
 
 # Small generic backoff helper used only in this quickstart
 # Include common transient statuses like 429/5xx to improve resilience.
@@ -138,75 +148,87 @@ def print_line_summaries(label: str, summaries: list[dict]) -> None:
 		)
 
 # 2) Create a record in the new table
-print("Create records (OData):")
-# Show planned creates before executing
-for _ in range(3):
-	plan_call(f"client.create('{entity_set}', payload)")
-pause("Execute Create")
+print("Create records (OData) demonstrating single create and bound CreateMultiple (multi):")
+
+# Define base payloads
+single_payload = {
+	f"{attr_prefix}_name": "Sample A",
+	code_key: "X001",
+	count_key: 42,
+	amount_key: 123.45,
+	when_key: "2025-01-01",
+	f"{attr_prefix}_active": True,
+}
+# Generate multiple payloads
+multi_payloads: list[dict] = []
+base_date = date(2025, 1, 2)
+for i in range(1, 16):
+	multi_payloads.append(
+		{
+			f"{attr_prefix}_name": f"Sample {i:02d}",
+			code_key: f"X{200 + i:03d}",
+			count_key: 5 * i,
+			amount_key: round(10.0 * i, 2),
+			when_key: (base_date + timedelta(days=i - 1)).isoformat(),
+			f"{attr_prefix}_active": True,
+		}
+	)
+
 record_ids: list[str] = []
 created_recs: list[dict] = []
-create_payloads = [
-	{
-		f"{attr_prefix}_name": "Sample A",
-		code_key: "X001",
-		count_key: 42,
-		amount_key: 123.45,
-		when_key: "2025-01-01",
-		f"{attr_prefix}_active": True,
-	},
-	{
-		f"{attr_prefix}_name": "Sample B",
-		code_key: "X002",
-		count_key: 7,
-		amount_key: 987.65,
-		when_key: "2025-01-02",
-		f"{attr_prefix}_active": True,
-	},
-	{
-		f"{attr_prefix}_name": "Sample C",
-		code_key: "X003",
-		count_key: 100,
-		amount_key: 222.22,
-		when_key: "2025-01-03",
-		f"{attr_prefix}_active": False,
-	},
-]
 
 try:
-	for payload in create_payloads:
-		log_call(f"client.create('{entity_set}', payload)")
-		rec = backoff_retry(lambda p=payload: client.create(entity_set, p))
-		created_recs.append(rec)
-		rid = rec.get(id_key)
-		if rid:
-			record_ids.append(rid)
+	# Single create (always returns full representation)
+	log_call(f"client.create('{entity_set}', single_payload)")
+	# Retry in case the custom table isn't fully provisioned immediately (404)
+	rec1 = backoff_retry(lambda: client.create(entity_set, single_payload))
+	created_recs.append(rec1)
+	rid1 = rec1.get(id_key)
+	if rid1:
+		record_ids.append(rid1)
+
+	# Multi create (list) now returns list[str] of IDs
+	log_call(f"client.create('{entity_set}', multi_payloads)")
+	multi_ids = backoff_retry(lambda: client.create(entity_set, multi_payloads))
+	if isinstance(multi_ids, list):
+		for mid in multi_ids:
+			if isinstance(mid, str):
+				record_ids.append(mid)
+	else:
+		print({"multi_unexpected_type": type(multi_ids).__name__, "value_preview": str(multi_ids)[:300]})
+
 	print({"entity": logical, "created_ids": record_ids})
-	# Summarize the created records from the returned payloads
 	summaries = []
 	for rec in created_recs:
 		summaries.append({"id": rec.get(id_key), **summary_from_record(rec)})
-	print_line_summaries("Created record summaries:", summaries)
+	print_line_summaries("Created record summaries (single only; multi-create returns IDs only):", summaries)
 except Exception as e:
+	# Surface detailed info for debugging (especially multi-create failures)
 	print(f"Create failed: {e}")
+	resp = getattr(e, 'response', None)
+	if resp is not None:
+		try:
+			print({
+				'status': resp.status_code,
+				'url': getattr(resp, 'url', None),
+				'body': resp.text[:2000] if getattr(resp, 'text', None) else None,
+				'headers': {k: v for k, v in getattr(resp, 'headers', {}).items() if k.lower() in ('request-id','activityid','dataverse-instanceversion','content-type')}
+			})
+		except Exception:
+			pass
 	sys.exit(1)
 
 pause("Next: Read record")
 
 # 3) Read record via OData
 print("Read (OData):")
-# Show planned reads before executing
-if 'record_ids' in locals() and record_ids:
-	for rid in record_ids:
-		plan_call(f"client.get('{entity_set}', '{rid}')")
-pause("Execute Read")
 try:
 	if record_ids:
-		summaries = []
-		for rid in record_ids:
-			log_call(f"client.get('{entity_set}', '{rid}')")
-			rec = backoff_retry(lambda r=rid: client.get(entity_set, r))
-			summaries.append({"id": rid, **summary_from_record(rec)})
-		print_line_summaries("Read record summaries:", summaries)
+		# Read only the first record and move on
+		target = record_ids[0]
+		log_call(f"client.get('{entity_set}', '{target}')")
+		rec = backoff_retry(lambda: client.get(entity_set, target))
+		print_line_summaries("Read record summary:", [{"id": target, **summary_from_record(rec)}])
 	else:
 		raise RuntimeError("No record created; skipping read.")
 except Exception as e:
@@ -246,7 +268,6 @@ try:
 
 	# Choose a single target to update to keep other records different
 	target_id = record_ids[0]
-	plan_call(f"client.update('{entity_set}', '{target_id}', update_data)")
 	pause("Execute Update")
 
 	# Update only the chosen record and summarize
@@ -268,7 +289,6 @@ except Exception as e:
 print("Query (SQL via Custom API):")
 try:
 	import time
-	plan_call(f"client.query_sql(\"SELECT TOP 2 * FROM {logical} ORDER BY {attr_prefix}_amount DESC\")")
 	pause("Execute SQL Query")
 
 	def _run_query():
@@ -297,19 +317,93 @@ try:
 	print_line_summaries("TDS record summaries (top 2 by amount):", tds_summaries)
 except Exception as e:
 	print(f"SQL via Custom API failed: {e}")
+
+# Pause between SQL query and retrieve-multiple demos
+pause("Retrieve multiple (OData paging demos)")
+
+# 4.5) Retrieve multiple via OData paging (scenarios)
+def run_paging_demo(label: str, *, top: Optional[int], page_size: Optional[int]) -> None:
+	print("")
+	print({"paging_demo": label, "top": top, "page_size": page_size})
+	total = 0
+	page_index = 0
+	_select = [id_key, code_key, amount_key, when_key]
+	_orderby = [f"{code_key} asc"]
+	for page in client.get_multiple(
+		entity_set,
+		select=_select,
+		filter=None,
+		orderby=_orderby,
+		top=top,
+		expand=None,
+		page_size=page_size,
+	):
+		page_index += 1
+		total += len(page)
+		print({
+			"page": page_index,
+			"page_size": len(page),
+			"sample": [
+				{"id": r.get(id_key), "code": r.get(code_key), "amount": r.get(amount_key), "when": r.get(when_key)}
+				for r in page[:5]
+			],
+		})
+	print({"paging_demo_done": label, "pages": page_index, "total_rows": total})
+	print("")
+
+print("")
+print("==============================")
+print("Retrieve multiple (OData paging demos)")
+print("==============================")
+try:
+	# 1) Tiny page size, no top: force multiple pages
+	run_paging_demo("page_size=2 (no top)", top=None, page_size=2)
+	pause("Next paging demo: top=3, page_size=2")
+
+	# 2) Limit total results while keeping small pages
+	run_paging_demo("top=3, page_size=2", top=3, page_size=2)
+	pause("Next paging demo: top=2 (default page size)")
+
+	# 3) Limit total results with default server page size (likely one page)
+	run_paging_demo("top=2 (default page size)", top=2, page_size=None)
+except Exception as e:
+	print(f"Retrieve multiple demos failed: {e}")
 # 5) Delete record
 print("Delete (OData):")
-# Show planned deletes before executing
+# Show deletes to be executed (concurrently via SDK delete)
 if 'record_ids' in locals() and record_ids:
-	for rid in record_ids:
-		plan_call(f"client.delete('{entity_set}', '{rid}')")
-pause("Execute Delete")
+	print({"delete_count": len(record_ids)})
+pause("Execute Delete (concurrent SDK calls)")
 try:
 	if record_ids:
-		for rid in record_ids:
-			log_call(f"client.delete('{entity_set}', '{rid}')")
-			backoff_retry(lambda r=rid: client.delete(entity_set, r))
-		print({"entity": logical, "deleted_ids": record_ids})
+		max_workers = min(8, len(record_ids))
+		log_call(f"concurrent delete {len(record_ids)} items from '{entity_set}' (workers={max_workers})")
+
+		successes: list[str] = []
+		failures: list[dict] = []
+
+		def _del_one(rid: str) -> tuple[str, bool, str | None]:
+			try:
+				log_call(f"client.delete('{entity_set}', '{rid}')")
+				backoff_retry(lambda: client.delete(entity_set, rid))
+				return (rid, True, None)
+			except Exception as ex:
+				return (rid, False, str(ex))
+
+		with ThreadPoolExecutor(max_workers=max_workers) as executor:
+			future_map = {executor.submit(_del_one, rid): rid for rid in record_ids}
+			for fut in as_completed(future_map):
+				rid, ok, err = fut.result()
+				if ok:
+					successes.append(rid)
+				else:
+					failures.append({"id": rid, "error": err})
+
+		print({
+			"entity": logical,
+			"delete_summary": {"requested": len(record_ids), "success": len(successes), "failures": len(failures)},
+			"failed": failures[:5],  # preview up to 5 failures
+		})
 	else:
 		raise RuntimeError("No record created; skipping delete.")
 except Exception as e:
@@ -319,15 +413,17 @@ pause("Next: Cleanup table")
 
 # 6) Cleanup: delete the custom table if it exists
 print("Cleanup (Metadata):")
-try:
-	# Delete if present, regardless of whether it was created in this run
-	log_call("client.get_table_info('SampleItem')")
-	info = client.get_table_info("SampleItem")
-	if info:
-		log_call("client.delete_table('SampleItem')")
-		client.delete_table("SampleItem")
-		print({"table_deleted": True})
-	else:
-		print({"table_deleted": False, "reason": "not found"})
-except Exception as e:
-	print(f"Delete table failed: {e}")
+if delete_table_at_end:
+	try:
+		log_call("client.get_table_info('SampleItem')")
+		info = client.get_table_info("SampleItem")
+		if info:
+			log_call("client.delete_table('SampleItem')")
+			client.delete_table("SampleItem")
+			print({"table_deleted": True})
+		else:
+			print({"table_deleted": False, "reason": "not found"})
+	except Exception as e:
+		print(f"Delete table failed: {e}")
+else:
+	print({"table_deleted": False, "reason": "user opted to keep table"})


### PR DESCRIPTION
- Support bulk create, calling CreateMultiple API
- Support bulk retrieve, accepting standard API GET params ($select, $top, $filter, $orderby) in OData format and yielding paged results
- README updates
- quickstart updates (incorporating above changes, plus adding optional table deletion for quicker runs and optional keyboard-waits for better demo-ability)

Copilot summary:

**Bulk operations and paging support:**

* Added support for bulk record creation: Passing a list of payloads to `create` invokes the `CreateMultiple` action, returning a list of GUIDs for created records. This is reflected in both the SDK (`DataverseClient.create`) and documentation. [[1]](diffhunk://#diff-648cf8496f6d6d5d96090028a69a6b4353961fff792009196aff7e81d38ece59L66-R90) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R8) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R19) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R110-R198) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R234-R235) [[6]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9L141-R231)
* Implemented `get_multiple` for paged retrieval: New `DataverseClient.get_multiple` method yields pages of records, supporting `$top` and `page_size` for server-driven paging. Examples and documentation illustrate usage and semantics. [[1]](diffhunk://#diff-648cf8496f6d6d5d96090028a69a6b4353961fff792009196aff7e81d38ece59R142-R166) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R19) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R70) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R110-R198) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R234-R235) [[6]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9R320-R406)

**Quickstart script improvements:**

* Updated quickstart to demonstrate bulk create, paged retrieval, and concurrent deletes: The script now shows single and bulk record creation, runs multiple paging demos, and deletes records concurrently with error handling and summary reporting. [[1]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9L141-R231) [[2]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9R320-R406) [[3]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9R416-L323)
* Added interactive options for pausing between steps and cleaning up the test table: Users can control whether to pause between steps and whether to delete the custom table at the end. [[1]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9R14-R43) [[2]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9R416-L323) [[3]](diffhunk://#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9R428-R429)

**Documentation updates:**

* Expanded README to describe new bulk and paging features, including usage notes, parameter explanations, and limitations. Clarified that general-purpose batching and multi-record update/delete are not yet supported. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18-R19) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R70) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R110-R198) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R234-R235) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L151-R249)