### PR TITLE
UpdateMultiple v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A minimal Python SDK to use Microsoft Dataverse as a database for Azure AI Found
 - Read (SQL) — Execute read-only T‑SQL via the McpExecuteSqlQuery Custom API. Returns `list[dict]`.
 - OData CRUD — Thin wrappers over Dataverse Web API (create/get/update/delete).
 - Bulk create — Pass a list of records to `create(...)` to invoke the bound `CreateMultiple` action; returns `list[str]` of GUIDs. If `@odata.type` is absent the SDK resolves the logical name from metadata (cached).
-- Bulk update — Call `update_multiple(entity_set, records)` to invoke the bound `UpdateMultiple` action; returns nothing (transactional fire-and-forget). Each record must include the real primary key attribute (e.g. `accountid`).
+- Bulk update — Call `update_multiple(entity_set, records)` to invoke the bound `UpdateMultiple` action; returns nothing. Each record must include the real primary key attribute (e.g. `accountid`).
 - Retrieve multiple (paging) — Generator-based `get_multiple(...)` that yields pages, supports `$top` and Prefer: `odata.maxpagesize` (`page_size`).
 - Metadata helpers — Create/inspect/delete simple custom tables (EntityDefinitions + Attributes).
 - Pandas helpers — Convenience DataFrame oriented wrappers for quick prototyping/notebooks.
@@ -135,7 +135,7 @@ print({"created_ids": ids})
 
 ## Bulk update (UpdateMultiple)
 
-Use `update_multiple(entity_set, records)` for a transactional batch update. The method returns `None` regardless of service response; this avoids exposing inconsistent behavior across environments that may or may not emit updated IDs.
+Use `update_multiple(entity_set, records)` for a transactional batch update. The method returns `None`.
 
 ```python
 ids = client.create("accounts", [
@@ -283,7 +283,7 @@ VS Code Tasks
 
 ## Limitations / Future Work
 - No general-purpose OData batching, upsert, or association operations yet.
-- `DeleteMultiple` not yet exposed; `UpdateMultiple` is available but returns no IDs (fire-and-forget semantics in this SDK version).
+- `DeleteMultiple` not yet exposed.
 - Minimal retry policy in library (network-error only); examples include additional backoff for transient Dataverse consistency.
 - Entity naming conventions in Dataverse: for multi-create the SDK resolves logical names from entity set metadata.
 

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -305,9 +305,8 @@ try:
 		backoff_retry(lambda: client.update_multiple(entity_set, bulk_updates))
 		print({"bulk_update_requested": len(bulk_updates), "bulk_update_completed": True})
 		# Verify the updated count values by refetching the subset
-		# (Individual gets keep the example simple and avoid crafting a complex $filter.)
 		verification = []
-		# Small delay to reduce risk of any brief replication delay (usually unnecessary)
+		# Small delay to reduce risk of any brief replication delay
 		time.sleep(1)
 		for rid in subset:
 			rec = backoff_retry(lambda rid=rid: client.get(entity_set, rid))

--- a/src/dataverse_sdk/client.py
+++ b/src/dataverse_sdk/client.py
@@ -123,8 +123,7 @@ class DataverseClient:
         Returns
         -------
         None
-            On success returns nothing. The underlying action does not reliably emit updated IDs across
-            environments; for predictable semantics the SDK returns None.
+            On success returns nothing.
         """
         self._get_odata().update_multiple(entity, records)
         return None

--- a/src/dataverse_sdk/odata.py
+++ b/src/dataverse_sdk/odata.py
@@ -250,11 +250,7 @@ class ODataClient:
         headers = self._headers().copy()
         r = self._request("post", url, headers=headers, json=payload)
         r.raise_for_status()
-        try:
-            body = r.json() if r.text else {}
-        except ValueError:
-            body = {}
-        # Intentionally ignore response content: no stable contract for IDs across environments.
+       # Intentionally ignore response content: no stable contract for IDs across environments.
         return None
 
     def delete(self, entity_set: str, key: str) -> None:


### PR DESCRIPTION
Basic UpdateMultiple support.

TBD:
- Returns None, as the underlying API call doesn't reliably return anything (204 No Content on my org, possibly sometimes a list of ID's on other environments). Need to discuss if the SDK or wrapper should support returning full record representations (DataverseClient apparently does this).
- ID/key handling is very basic (expects full primary key attribute for each record) - alternate key support or accepting just 'id' rather than full logicalname id could be useful for future iterations.


Copilot summary:

**Bulk update feature:**

* Added `update_multiple` method to `DataverseClient` (`src/dataverse_sdk/client.py`) and its implementation in `ODataClient` (`src/dataverse_sdk/odata.py`). This method allows transactional bulk updates using the bound `UpdateMultiple` action and requires each record to include the primary key attribute. It returns nothing on success, aligning with Dataverse's semantics. [[1]](diffhunk://#diff-648cf8496f6d6d5d96090028a69a6b4353961fff792009196aff7e81d38ece59R113-R130) [[2]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7R199-R255)

**Documentation and usage updates:**

* Updated `README.md` to document the new bulk update capability, including usage notes, method signature, and limitations. Added code samples demonstrating how to use `update_multiple` for batch updates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R111) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-R158)
* Clarified that `DeleteMultiple` is not yet exposed and removed outdated limitation regarding `UpdateMultiple` in the limitations section.

**Examples:**

* Added a bulk update demonstration to `examples/quickstart.py`, showing how to update multiple records and verify the changes. The example includes error handling and verification logic.