### PR TITLE
Updated create table statement to allow explicitly passing prefix in column names

### DIFF
--- a/src/dataverse_sdk/odata.py
+++ b/src/dataverse_sdk/odata.py
@@ -540,7 +540,10 @@ class ODataClient:
         for col_name, dtype in schema.items():
             # Use same publisher prefix segment as entity_schema if present; else default to 'new_'.
             publisher = entity_schema.split("_", 1)[0] if "_" in entity_schema else "new"
-            attr_schema = f"{publisher}_{self._to_pascal(col_name)}"
+            if col_name.lower().startswith(f"{publisher}_"):
+                attr_schema = col_name
+            else:
+                attr_schema = f"{publisher}_{self._to_pascal(col_name)}"
             payload = self._attribute_payload(attr_schema, dtype)
             if not payload:
                 raise ValueError(f"Unsupported column type '{dtype}' for '{col_name}'.")


### PR DESCRIPTION
Currently there is no way to explicitly pass full column names including prefix. If you do, it mangles the name to include the prefix value twice. Updated to check if the prefix is there and only default it in when it isn't.