### PR TITLE
Split create() into create() and create_multiple()

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ for r in rows:
 
 ## Bulk create (CreateMultiple)
 
-Pass a list of payloads to `create(entity_set, payloads)` to invoke the collection-bound `Microsoft.Dynamics.CRM.CreateMultiple` action. The method returns a `list[str]` of created record IDs.
+Call `create_multiple(entity_set, payloads)` to invoke the collection-bound `Microsoft.Dynamics.CRM.CreateMultiple` action. The method returns a `list[str]` of created record IDs.
 
 ```python
 # Bulk create accounts (returns list of GUIDs)
@@ -128,7 +128,7 @@ payloads = [
 	{"name": "Fabrikam"},
 	{"name": "Northwind"},
 ]
-ids = client.create("accounts", payloads)
+ids = client.create_multiple("accounts", payloads)
 assert isinstance(ids, list) and all(isinstance(x, str) for x in ids)
 print({"created_ids": ids})
 ```
@@ -268,7 +268,7 @@ client.delete_table("SampleItem")        # delete the table
 
 Notes:
 - `create/update` return the full record using `Prefer: return=representation`.
-- Passing a list of payloads to `create` triggers bulk create and returns `list[str]` of IDs.
+- Use `create_multiple` for bulk create; single `create` only accepts a dict payload.
 - Use `get_multiple` for paging through result sets; prefer `select` to limit columns.
 - For CRUD methods that take a record id, pass the GUID string (36-char hyphenated). Parentheses around the GUID are accepted but not required.
 * SQL queries are executed directly against entity set endpoints using the `?sql=` parameter. Supported subset only (single SELECT, optional WHERE/TOP/ORDER BY, alias). Unsupported constructs will be rejected by the service.

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -188,9 +188,9 @@ try:
 	if rid1:
 		record_ids.append(rid1)
 
-	# Multi create (list) now returns list[str] of IDs
-	log_call(f"client.create('{entity_set}', multi_payloads)")
-	multi_ids = backoff_retry(lambda: client.create(entity_set, multi_payloads))
+	# Multi create via create_multiple now returns list[str] of IDs
+	log_call(f"client.create_multiple('{entity_set}', multi_payloads)")
+	multi_ids = backoff_retry(lambda: client.create_multiple(entity_set, multi_payloads))
 	if isinstance(multi_ids, list):
 		for mid in multi_ids:
 			if isinstance(mid, str):

--- a/src/dataverse_sdk/client.py
+++ b/src/dataverse_sdk/client.py
@@ -63,33 +63,19 @@ class DataverseClient:
         return self._odata
 
     # CRUD
-    def create(self, entity: str, record_data: Union[Dict[str, Any], List[Dict[str, Any]]]) -> Union[Dict[str, Any], List[str]]:
-        """Create one or more records.
+    def create(self, entity: str, record_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a single record.
 
-        Behaviour:
-        - Single: returns the created record (dict) using Prefer: return=representation.
-        - Multiple: uses bound CreateMultiple action and returns list[str] of created record IDs.
-
-        Parameters
-        ----------
-        entity : str
-            Entity set name (plural logical name), e.g., ``"accounts"``.
-        record_data : dict | list[dict]
-            Single record payload or list of records for multi-create.
-
-        Returns
-        -------
-        dict | list[str]
-            Dict for single create, list of GUID strings for multi-create.
-
-        Raises
-        ------
-        requests.exceptions.HTTPError
-            If the request fails.
-        TypeError
-            If ``record_data`` is not a dict or list of dict.
+        Returns the created record representation (if provided by the service).
         """
         return self._get_odata().create(entity, record_data)
+
+    def create_multiple(self, entity: str, records: List[Dict[str, Any]]) -> List[str]:
+        """Create multiple records via the bound CreateMultiple action.
+
+        Returns list of created record GUID strings.
+        """
+        return self._get_odata().create_multiple(entity, records)
 
     def update(self, entity: str, record_id: str, record_data: dict) -> dict:
         """Update a record and return its full representation.


### PR DESCRIPTION
Splitting create in to create/create_multiple, to align with current update/update_multiple and get/get_multiple implementations.