### PR TITLE
add user agent to calls and consolidate headers calls into _request

### DIFF
--- a/examples/quickstart_file_upload.py
+++ b/examples/quickstart_file_upload.py
@@ -191,7 +191,7 @@ def ensure_file_attribute_generic(schema_name: str, label: str, key_prefix: str)
             f"{odata.api}/EntityDefinitions({meta_id})/Attributes?$select=SchemaName&$filter="
             f"SchemaName eq '{schema_name}'"
         )
-        r = odata._request("get", url, headers=odata._headers())
+        r = odata._request("get", url)
         val = []
         try:
             val = r.json().get("value", [])
@@ -215,7 +215,7 @@ def ensure_file_attribute_generic(schema_name: str, label: str, key_prefix: str)
     }
     try:
         url = f"{odata.api}/EntityDefinitions({meta_id})/Attributes"
-        r = odata._request("post", url, headers=odata._headers(), json=payload)
+        r = odata._request("post", url, json=payload)
         print({f"{key_prefix}_file_attribute_created": True})
         time.sleep(2)
         return True
@@ -288,7 +288,7 @@ if run_small:
         print({"small_upload_completed": True, "small_source_size": small_file_size})
         odata = client._get_odata()
         dl_url_single = f"{odata.api}/{entity_set}({record_id})/{small_file_attr_logical}/$value"  # raw entity_set URL OK
-        resp_single = odata._request("get", dl_url_single, headers=odata._headers())
+        resp_single = odata._request("get", dl_url_single)
         content_single = resp_single.content or b""
         import hashlib  # noqa: WPS433
         downloaded_hash = hashlib.sha256(content_single).hexdigest() if content_single else None
@@ -313,7 +313,7 @@ if run_small:
             mode="small",
         ))
         print({"small_replace_upload_completed": True, "small_replace_source_size": replace_size_small})
-        resp_single_replace = odata._request("get", dl_url_single, headers=odata._headers())
+        resp_single_replace = odata._request("get", dl_url_single)
         content_single_replace = resp_single_replace.content or b""
         downloaded_hash_replace = hashlib.sha256(content_single_replace).hexdigest() if content_single_replace else None
         hash_match_replace = (downloaded_hash_replace == replace_hash_small) if (downloaded_hash_replace and replace_hash_small) else None
@@ -343,7 +343,7 @@ if run_chunk:
         print({"chunk_upload_completed": True})
         odata = client._get_odata()
         dl_url_chunk = f"{odata.api}/{entity_set}({record_id})/{chunk_file_attr_logical}/$value"  # raw entity_set for download
-        resp_chunk = odata._request("get", dl_url_chunk, headers=odata._headers())
+        resp_chunk = odata._request("get", dl_url_chunk)
         content_chunk = resp_chunk.content or b""
         import hashlib  # noqa: WPS433
         dst_hash_chunk = hashlib.sha256(content_chunk).hexdigest() if content_chunk else None
@@ -367,7 +367,7 @@ if run_chunk:
             mode="chunk",
         ))
         print({"chunk_replace_upload_completed": True})
-        resp_chunk_replace = odata._request("get", dl_url_chunk, headers=odata._headers())
+        resp_chunk_replace = odata._request("get", dl_url_chunk)
         content_chunk_replace = resp_chunk_replace.content or b""
         dst_hash_chunk_replace = hashlib.sha256(content_chunk_replace).hexdigest() if content_chunk_replace else None
         hash_match_chunk_replace = (dst_hash_chunk_replace == replace_hash_chunk) if (dst_hash_chunk_replace and replace_hash_chunk) else None


### PR DESCRIPTION
This pull request refactors how HTTP headers are handled in the `dataverse_sdk` OData client and its file upload utilities. The main improvement is centralizing header management, so standard headers (like authentication and user agent) are automatically merged with any custom headers provided for requests. This reduces duplicated code and ensures consistency across all API calls. Several methods in both the SDK and example scripts are updated to leverage this new approach, simplifying their logic and making header handling more robust.

**Header management and request refactoring:**

* Introduced a `_merge_headers` method in `src/dataverse_sdk/odata.py` to combine standard OData headers (including a new `User-Agent: DataversePythonSDK`) with any custom headers, and refactored the internal `_request` method to use it. [[1]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7R57-R74) [[2]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7R84-R85)
* Updated all client methods in `src/dataverse_sdk/odata.py` to remove direct calls to `_headers()` and instead rely on the centralized header merging, resulting in cleaner and more maintainable code. [[1]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L152-R164) [[2]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L187-R198) [[3]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L305-R315) [[4]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L356-R372) [[5]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L386-R391) [[6]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L424-R436) [[7]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L503-R511) [[8]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L557-R562) [[9]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L602-R607) [[10]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L620-R625) [[11]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L996-R1006) [[12]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L1007-R1017)

**File upload utility updates:**

* Refactored file upload methods in `src/dataverse_sdk/odata_upload_files.py` to build only the minimal required custom headers and rely on the client to inject standard headers, replacing `_send` with `_request` for consistency. [[1]](diffhunk://#diff-8d47a94dd62250f8bdbb40eccb5db8d32e6d570cc21846deeaef824a99c62703L97-R106) [[2]](diffhunk://#diff-8d47a94dd62250f8bdbb40eccb5db8d32e6d570cc21846deeaef824a99c62703L149-R156)

**Example script cleanup:**

* Updated all example usage in `examples/quickstart_file_upload.py` to remove explicit header passing when calling `_request`, making the examples simpler and less error-prone. [[1]](diffhunk://#diff-9e95d2c0fe80ef43b780038232129f6e0516ef8af8d065383ac25dae5acbd0f4L194-R194) [[2]](diffhunk://#diff-9e95d2c0fe80ef43b780038232129f6e0516ef8af8d065383ac25dae5acbd0f4L218-R218) [[3]](diffhunk://#diff-9e95d2c0fe80ef43b780038232129f6e0516ef8af8d065383ac25dae5acbd0f4L291-R291) [[4]](diffhunk://#diff-9e95d2c0fe80ef43b780038232129f6e0516ef8af8d065383ac25dae5acbd0f4L316-R316) [[5]](diffhunk://#diff-9e95d2c0fe80ef43b780038232129f6e0516ef8af8d065383ac25dae5acbd0f4L346-R346) [[6]](diffhunk://#diff-9e95d2c0fe80ef43b780038232129f6e0516ef8af8d065383ac25dae5acbd0f4L370-R370)

**Error handling improvements:**

* Improved error handling in `_optionset_map` to use the new request logic and raise clear exceptions after retrying, instead of manually checking status codes. [[1]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L794-R812) [[2]](diffhunk://#diff-c2deb4bb60ea5f78598c4b83a5a3450bd2e966e6aae99e0938443960360a4de7L827-R845)