### PR TITLE
ci-pr: don't exit on format issues

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -28,6 +28,7 @@ steps:
 - script: |
     black src tests --check
   displayName: 'Check format with black'
+  continueOnError: true  # TODO: fix detected formatting errors and remove this line
 
 - script: |
     # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
This pull request makes a small change to the CI pipeline configuration, allowing the formatting check with `black` to continue even if errors are detected. This is a temporary measure until formatting errors are fixed.

* [`.azdo/ci-pr.yaml`](diffhunk://#diff-50b28cd1647a6801f28c6abec92ffc548ebdd47848c528f5b9baf0791c47fd7cR31): Added `continueOnError: true` to the `black` formatting check step, so the pipeline does not fail on formatting issues.