### PR TITLE
Refactor configuration instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Python package allowing developers to connect to Dataverse environments for DD
 - Optional pandas integration (`PandasODataClient`) for DataFrame based create / get / query.
 
 Auth:
-- Accept only an `azure.core.credentials.TokenCredential` credential.
+- Accept only an `azure.core.credentials.TokenCredential` credential. See full supported list at https://learn.microsoft.com/en-us/dotnet/api/azure.core.tokencredential?view=azure-dotnet.
 - Token scope used by the SDK: `https://<yourorg>.crm.dynamics.com/.default` (derived from `base_url`).
 
 ## API Reference (Summary)


### PR DESCRIPTION
This pull request updates the documentation to simplify the configuration instructions for the Dataverse SDK. The main change is streamlining the configuration section in `README.md` to use a more straightforward authentication setup.

Documentation simplification:

* The configuration example now uses `InteractiveBrowserCredential` directly, removing references to `DataverseConfig` and its optional HTTP tunables for a cleaner, more accessible setup. (`README.md`, [README.mdL76-R85](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R85))