### PR TITLE
Add support for Python 3.14 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",


### PR DESCRIPTION
This pull request makes a minor update to the `pyproject.toml` configuration file, adding support for Python 3.14 in the package classifiers. This signals to users and tooling that the package is compatible with Python 3.14.