### PR TITLE
docs: fix API documentation link in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -93,7 +93,7 @@ All examples use Azure Identity for authentication. Common patterns:
 
 ## 📖 Documentation
 
-For detailed API documentation, visit: [Dataverse SDK Documentation](link-to-docs)
+For detailed API documentation, visit: [Dataverse SDK Documentation](https://learn.microsoft.com/python/api/dataverse-sdk-docs-python/dataverse-overview?view=dataverse-sdk-python-latest)
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
This pull request updates the API documentation link in the `examples/README.md` file to point to the official Microsoft Learn documentation for the Dataverse SDK for Python.

* Updated the API documentation link in `examples/README.md` to the official Microsoft Learn Dataverse SDK for Python documentation.