### PR TITLE
fix for links on pypi and update walkthrough schema -> columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,17 +254,17 @@ client.upload_file(
 
 ### More sample code
 
-Explore our comprehensive examples in the [`examples/`](examples/) directory:
+Explore our comprehensive examples in the [`examples/`](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/tree/main/examples) directory:
 
 **🌱 Getting Started:**
-- **[Installation & Setup](examples/basic/installation_example.py)** - Validate installation and basic usage patterns
-- **[Functional Testing](examples/basic/functional_testing.py)** - Test core functionality in your environment
+- **[Installation & Setup](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/blob/main/examples/basic/installation_example.py)** - Validate installation and basic usage patterns
+- **[Functional Testing](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/blob/main/examples/basic/functional_testing.py)** - Test core functionality in your environment
 
 **🚀 Advanced Usage:**
-- **[Complete Walkthrough](examples/advanced/walkthrough.py)** - Full feature demonstration with production patterns  
-- **[File Upload](examples/advanced/file_upload.py)** - Upload files to Dataverse file columns
+- **[Complete Walkthrough](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/blob/main/examples/advanced/walkthrough.py)** - Full feature demonstration with production patterns  
+- **[File Upload](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/blob/main/examples/advanced/file_upload.py)** - Upload files to Dataverse file columns
 
-📖 See the [examples README](examples/README.md) for detailed guidance and learning progression.
+📖 See the [examples README](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/blob/main/examples/README.md) for detailed guidance and learning progression.
 
 ### Additional documentation
 

--- a/examples/advanced/walkthrough.py
+++ b/examples/advanced/walkthrough.py
@@ -79,7 +79,7 @@ def main():
         print(f"  Logical Name: {table_info.get('table_logical_name')}")
         print(f"  Entity Set: {table_info.get('entity_set_name')}")
     else:
-        log_call(f"client.create_table('{table_name}', schema={{...}})")
+        log_call(f"client.create_table('{table_name}', columns={{...}})")
         columns = {
             "new_Title": "string",
             "new_Quantity": "int",


### PR DESCRIPTION
This pull request updates documentation and example code references to improve clarity and usability. The most important changes include updating all example links in the `README.md` to use absolute GitHub URLs, and clarifying a log message in the advanced walkthrough example.

Documentation improvements:

* Updated all example links in `README.md` from relative paths to absolute GitHub URLs for easier navigation and sharing.
* Changed the reference to the examples README in `README.md` to use an absolute GitHub URL.

Example code clarity:

* Revised a log message in `examples/advanced/walkthrough.py` to clarify that the `create_table` method uses a `columns` argument instead of a generic `schema`.