### PR TITLE
Update CI trigger to include main branch

### DIFF
--- a/.azdo/ci-pr.yaml
+++ b/.azdo/ci-pr.yaml
@@ -4,7 +4,8 @@
 pr:
 - main
 
-trigger: none  # Only run on PRs, not on direct pushes
+trigger:
+- main
 
 resources:
   repositories:


### PR DESCRIPTION
This pull request updates the Azure DevOps pipeline configuration to enable CI builds on direct pushes to the `main` branch, in addition to pull requests.

Pipeline trigger configuration:

* [`.azdo/ci-pr.yaml`](diffhunk://#diff-50b28cd1647a6801f28c6abec92ffc548ebdd47848c528f5b9baf0791c47fd7cL7-R8): Changed the `trigger` setting to include the `main` branch, so that the pipeline runs on both pull requests and direct pushes to `main`.