### PR TITLE
cache empty result for picklist label retrieval in _ODataClient

### DIFF
--- a/src/PowerPlatform/Dataverse/data/_odata.py
+++ b/src/PowerPlatform/Dataverse/data/_odata.py
@@ -1015,7 +1015,9 @@ class _ODataClient(_ODataFileUpload):
         body_type = r_type.json()
         items = body_type.get("value", []) if isinstance(body_type, dict) else []
         if not items:
-            return None
+            # cache empty result
+            self._picklist_label_cache[cache_key] = {"map": {}, "ts": now}
+            return {}
         attr_md = items[0]
         if attr_md.get("AttributeType") not in ("Picklist", "PickList"):
             self._picklist_label_cache[cache_key] = {"map": {}, "ts": now}


### PR DESCRIPTION
This pull request updates the `_optionset_map` method to cache empty results instead of returning `None` when no items are found. This change ensures that empty lookups are cached, which can improve performance by avoiding repeated queries for missing option sets.

Caching improvements:

* Modified `_optionset_map` in `src/PowerPlatform/Dataverse/data/_odata.py` to cache empty results in `_picklist_label_cache` and return an empty dictionary instead of `None` when no items are found.