### PR TITLE
fix: client.list_tables return type inconsistent with type hint & doc…

### DIFF
--- a/src/PowerPlatform/Dataverse/client.py
+++ b/src/PowerPlatform/Dataverse/client.py
@@ -527,7 +527,7 @@ class DataverseClient:
 
         Example:
             List all non-private tables and print their logical names::
-    
+
                 tables = client.list_tables()
                 for table in tables:
                     print(table["LogicalName"])


### PR DESCRIPTION
`client.list_tables()` type hint updated and docstring updated to reflect that the method returns a list of `EntityMetadata` dictionaries, as yielded by the `/EntityDefinitions` API endpoint, not a list of `str`.