### PR TITLE
Preserve @odata keys when normalizing record keys

### DIFF
--- a/src/PowerPlatform/Dataverse/data/_odata.py
+++ b/src/PowerPlatform/Dataverse/data/_odata.py
@@ -106,7 +106,7 @@ class _ODataClient(_ODataFileUpload):
 
         # Preserve OData annotation keys as they are case sensitive
         for k, v in record.items():
-            if isinstance(k, str) and "@odata" in k:
+            if isinstance(k, str) and "@odata" in k.lower():
                 new_record[k] = v
             else:
                 new_record[k.lower() if isinstance(k, str) else k] = v


### PR DESCRIPTION
The _lowercase_keys helper function previously lowercases all string keys which unintentionally breaks OData keys such as @odata.bind. These keys are case sensitive and must remain unchanged for Dataverse to interpret them correctly. 