### PR TITLE
Add black formatting rule to dev skill

### DIFF
--- a/.claude/skills/dataverse-sdk-dev/SKILL.md
+++ b/.claude/skills/dataverse-sdk-dev/SKILL.md
@@ -26,3 +26,4 @@ This skill provides guidance for developers working on the PowerPlatform Dataver
 8. **No noqa comments** - Do not add `# noqa: BLE001` or similar linter suppression comments
 9. **Document public APIs** - Add Sphinx-style docstrings with examples for public methods
 10. **Define __all__ in module files, not __init__.py** - Use `__all__` to control exports in the actual module file (e.g., errors.py), not in `__init__.py`.
+11. **Run black before committing** - Always run `python -m black <changed files>` before committing. CI will reject unformatted code. Config is in `pyproject.toml` under `[tool.black]`.

--- a/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-dev/SKILL.md
+++ b/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-dev/SKILL.md
@@ -26,3 +26,4 @@ This skill provides guidance for developers working on the PowerPlatform Dataver
 8. **No noqa comments** - Do not add `# noqa: BLE001` or similar linter suppression comments
 9. **Document public APIs** - Add Sphinx-style docstrings with examples for public methods
 10. **Define __all__ in module files, not __init__.py** - Use `__all__` to control exports in the actual module file (e.g., errors.py), not in `__init__.py`.
+11. **Run black before committing** - Always run `python -m black <changed files>` before committing. CI will reject unformatted code. Config is in `pyproject.toml` under `[tool.black]`.


### PR DESCRIPTION
## Summary

- Adds "run black before committing" as a new rule in the dataverse-sdk-dev Claude skill
- Updated both copies (.claude/skills/ and src/.../claude_skill/)

Prevents CI formatting failures when Claude Code generates or modifies Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)