### PR TITLE
Bump version to 0.1.0b5 for next development cycle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,3 +110,15 @@ Brief summary of the release
 - Bug fix 1 (#125)
 - Bug fix 2 (#126)
 ```
+
+**Post-Release Version Bump:**
+
+After tagging and publishing a release, immediately bump the version on `main` to the next
+development target. This ensures builds from source are clearly distinguished from the
+published release:
+
+```bash
+# After publishing v0.1.0b4, bump to v0.1.0b5 on main
+# Update both pyproject.toml and src/PowerPlatform/Dataverse/__version__.py
+# Commit directly to main: "Bump version to 0.1.0b5 for next development cycle"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PowerPlatform-Dataverse-Client"
-version = "0.1.0b4"
+version = "0.1.0b5"
 description = "Python SDK for Microsoft Dataverse"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [{name = "Microsoft Corporation"}]

--- a/src/PowerPlatform/Dataverse/__version__.py
+++ b/src/PowerPlatform/Dataverse/__version__.py
@@ -3,4 +3,4 @@
 
 """Version information for PowerPlatform-Dataverse-Client package."""
 
-__version__ = "0.1.0b4"
+__version__ = "0.1.0b5"


### PR DESCRIPTION
Post-release version bump. Ensures builds from source are distinguishable from the published b4 release.

Also adds the post-release version bump step to CONTRIBUTING.md.