### PR TITLE
Bump version to 0.1.0b7 for next development cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PowerPlatform-Dataverse-Client"
-version = "0.1.0b6"
+version = "0.1.0b7"
 description = "Python SDK for Microsoft Dataverse"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [{name = "Microsoft Corporation"}]


### PR DESCRIPTION
Post-release version bump to 0.1.0b7 after publishing v0.1.0b6 to PyPI.