### PR TITLE
Add acquire_token() public method for cross-resource auth

### DIFF
--- a/.claude/skills/dataverse-sdk-use/SKILL.md
+++ b/.claude/skills/dataverse-sdk-use/SKILL.md
@@ -79,6 +79,20 @@ with DataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
 client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 ```
 
+### Acquiring Tokens for Other Microsoft Resources
+
+`client.auth.acquire_token(resource_url)` returns an OAuth2 token from the same credential for any AAD-protected Microsoft resource (e.g. a linked Finance & Operations environment). The `/.default` scope is appended automatically.
+
+```python
+# Token for a linked Finance & Operations environment
+fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
+
+# Use the F&O token to call F&O OData / Custom Service endpoints directly
+headers = {"Authorization": f"Bearer {fno_token}"}
+```
+
+The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `Odata.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+
 ### CRUD Operations
 
 #### Create Records

--- a/.claude/skills/dataverse-sdk-use/SKILL.md
+++ b/.claude/skills/dataverse-sdk-use/SKILL.md
@@ -81,17 +81,17 @@ client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 
 ### Acquiring Tokens for Other Microsoft Resources
 
-`client.auth.acquire_token(resource_url)` returns an OAuth2 token from the same credential for any AAD-protected Microsoft resource (e.g. a linked Finance & Operations environment). The `/.default` scope is appended automatically.
+`client.auth.acquire_token(resource_url)` returns an OAuth2 token from the same credential for any AAD-protected Microsoft resource (e.g. a linked ERP environment, i.e. Microsoft Dynamics 365 Finance & Operations). The `/.default` scope is appended automatically.
 
 ```python
-# Token for a linked Finance & Operations environment
+# Token for a linked ERP environment
 fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
 
-# Use the F&O token to call F&O OData / Custom Service endpoints directly
+# Use the token to call ERP OData / Custom Service endpoints directly
 headers = {"Authorization": f"Bearer {fno_token}"}
 ```
 
-The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+The customer's AAD app must already have the required permission on the target resource. For ERP the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
 
 ### CRUD Operations
 

--- a/.claude/skills/dataverse-sdk-use/SKILL.md
+++ b/.claude/skills/dataverse-sdk-use/SKILL.md
@@ -91,7 +91,7 @@ fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
 headers = {"Authorization": f"Bearer {fno_token}"}
 ```
 
-The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `Odata.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
 
 ### CRUD Operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `client.query.odata_select()`, `client.query.odata_expands()`, `client.query.odata_expand()`, `client.query.odata_bind()` emit `DeprecationWarning`; navigation-property helpers are replaced by `QueryBuilder.expand()` (#175)
 
 ### Added
-- `client.auth.acquire_token(resource_url)` -- acquire an OAuth2 access token for any Microsoft AAD-protected resource (for example a linked Finance & Operations environment) using the same credential the Dataverse client was constructed with. The `/.default` scope is appended automatically; token caching and refresh remain the credential's responsibility. The internal Dataverse request path now goes through the same method, removing the inline scope construction in `_ODataClient._headers()`.
+- `client.auth.acquire_token(resource_url)` -- acquire an OAuth2 access token for any Microsoft AAD-protected resource (for example a linked ERP environment, i.e. Microsoft Dynamics 365 Finance & Operations) using the same credential the Dataverse client was constructed with. The `/.default` scope is appended automatically; token caching and refresh remain the credential's responsibility. The internal Dataverse request path now goes through the same method, removing the inline scope construction in `_ODataClient._headers()`.
 
 ## [0.1.0b10] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `QueryBuilder.execute(by_page=True)` and `execute(by_page=False)` emit `UserWarning`; use `execute_pages()` and `execute()` respectively (#175)
 - `client.query.odata_select()`, `client.query.odata_expands()`, `client.query.odata_expand()`, `client.query.odata_bind()` emit `DeprecationWarning`; navigation-property helpers are replaced by `QueryBuilder.expand()` (#175)
 
+### Added
+- `client.auth.acquire_token(resource_url)` -- acquire an OAuth2 access token for any Microsoft AAD-protected resource (for example a linked Finance & Operations environment) using the same credential the Dataverse client was constructed with. The `/.default` scope is appended automatically; token caching and refresh remain the credential's responsibility. The internal Dataverse request path now goes through the same method, removing the inline scope construction in `_ODataClient._headers()`.
+
 ## [0.1.0b10] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,16 +117,16 @@ Ref: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity?
 
 #### Acquiring tokens for other Microsoft resources
 
-The same credential can be used to acquire tokens for any Microsoft AAD-protected resource the caller has access to -- notably a Finance & Operations environment linked to the same Dataverse org. Use `client.auth.acquire_token(resource_url)` to obtain a token without constructing a second credential:
+The same credential can be used to acquire tokens for any Microsoft AAD-protected resource the caller has access to -- notably a linked ERP environment (Microsoft Dynamics 365 Finance & Operations) associated with the same Dataverse org. Use `client.auth.acquire_token(resource_url)` to obtain a token without constructing a second credential:
 
 ```python
-# Token for a linked Finance & Operations environment
+# Token for a linked ERP environment
 fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
 
 headers = {"Authorization": f"Bearer {fno_token}"}
 ```
 
-The `/.default` scope is appended automatically. The customer's AAD app must already have the required permission on the target resource and admin consent granted. For Finance & Operations the standard permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+The `/.default` scope is appended automatically. The customer's AAD app must already have the required permission on the target resource and admin consent granted. For ERP the standard permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
 
 ## Key concepts
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ Ref: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity?
 
 > **Set up service principal authentication**: To use `ClientSecretCredential` or `CertificateCredential` you must first register an Azure AD app and grant it access to your Dataverse environment as an application user. See **[Use OAuth with Dataverse](https://learn.microsoft.com/power-apps/developer/data-platform/authenticate-oauth)** (covers app registration, obtaining `tenant_id` / `client_id` / `client_secret`, all credential types, and security configuration).
 
+#### Acquiring tokens for other Microsoft resources
+
+The same credential can be used to acquire tokens for any Microsoft AAD-protected resource the caller has access to -- notably a Finance & Operations environment linked to the same Dataverse org. Use `client.auth.acquire_token(resource_url)` to obtain a token without constructing a second credential:
+
+```python
+# Token for a linked Finance & Operations environment
+fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
+
+headers = {"Authorization": f"Bearer {fno_token}"}
+```
+
+The `/.default` scope is appended automatically. The customer's AAD app must already have the required permission on the target resource and admin consent granted. For Finance & Operations the standard permissions are `Odata.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+
 ## Key concepts
 
 The SDK provides a simple, pythonic interface for Dataverse operations:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
 headers = {"Authorization": f"Bearer {fno_token}"}
 ```
 
-The `/.default` scope is appended automatically. The customer's AAD app must already have the required permission on the target resource and admin consent granted. For Finance & Operations the standard permissions are `Odata.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+The `/.default` scope is appended automatically. The customer's AAD app must already have the required permission on the target resource and admin consent granted. For Finance & Operations the standard permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
 
 ## Key concepts
 

--- a/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
+++ b/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
@@ -79,6 +79,20 @@ with DataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
 client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 ```
 
+### Acquiring Tokens for Other Microsoft Resources
+
+`client.auth.acquire_token(resource_url)` returns an OAuth2 token from the same credential for any AAD-protected Microsoft resource (e.g. a linked Finance & Operations environment). The `/.default` scope is appended automatically.
+
+```python
+# Token for a linked Finance & Operations environment
+fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
+
+# Use the F&O token to call F&O OData / Custom Service endpoints directly
+headers = {"Authorization": f"Bearer {fno_token}"}
+```
+
+The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `Odata.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+
 ### CRUD Operations
 
 #### Create Records

--- a/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
+++ b/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
@@ -81,17 +81,17 @@ client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 
 ### Acquiring Tokens for Other Microsoft Resources
 
-`client.auth.acquire_token(resource_url)` returns an OAuth2 token from the same credential for any AAD-protected Microsoft resource (e.g. a linked Finance & Operations environment). The `/.default` scope is appended automatically.
+`client.auth.acquire_token(resource_url)` returns an OAuth2 token from the same credential for any AAD-protected Microsoft resource (e.g. a linked ERP environment, i.e. Microsoft Dynamics 365 Finance & Operations). The `/.default` scope is appended automatically.
 
 ```python
-# Token for a linked Finance & Operations environment
+# Token for a linked ERP environment
 fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
 
-# Use the F&O token to call F&O OData / Custom Service endpoints directly
+# Use the token to call ERP OData / Custom Service endpoints directly
 headers = {"Authorization": f"Bearer {fno_token}"}
 ```
 
-The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+The customer's AAD app must already have the required permission on the target resource. For ERP the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
 
 ### CRUD Operations
 

--- a/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
+++ b/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
@@ -91,7 +91,7 @@ fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
 headers = {"Authorization": f"Bearer {fno_token}"}
 ```
 
-The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `Odata.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+The customer's AAD app must already have the required permission on the target resource. For F&O the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
 
 ### CRUD Operations
 

--- a/src/PowerPlatform/Dataverse/core/_auth.py
+++ b/src/PowerPlatform/Dataverse/core/_auth.py
@@ -2,11 +2,12 @@
 # Licensed under the MIT license.
 
 """
-Authentication helpers for Dataverse.
+Authentication helpers.
 
 This module provides :class:`~PowerPlatform.Dataverse.core._auth._AuthManager`, a thin wrapper over any Azure Identity
-``TokenCredential`` for acquiring OAuth2 access tokens, and :class:`~PowerPlatform.Dataverse.core._auth._TokenPair` for
-storing the acquired token alongside its scope.
+``TokenCredential`` for acquiring OAuth2 access tokens for Microsoft AAD-protected resources -- Dataverse by default,
+and any other resource (e.g. a linked Finance & Operations environment) when an explicit scope is supplied --
+and :class:`~PowerPlatform.Dataverse.core._auth._TokenPair` for storing the acquired token alongside its scope.
 """
 
 from __future__ import annotations
@@ -44,7 +45,15 @@ class _TokenPair:
 
 class _AuthManager:
     """
-    Azure Identity-based authentication manager for Dataverse.
+    Azure Identity-based authentication manager.
+
+    Resource-agnostic: the scope passed to :meth:`_acquire_token` selects
+    the target resource. The Dataverse client supplies its own
+    ``<base_url>/.default`` scope on every internal request via
+    :meth:`acquire_token`, and the same method can be called externally
+    (through ``client.auth.acquire_token(...)``) to obtain tokens for
+    other Microsoft AAD-protected resources -- for example a linked
+    Finance & Operations environment.
 
     :param credential: Azure Identity credential implementation.
     :type credential: ~azure.core.credentials.TokenCredential
@@ -68,3 +77,43 @@ class _AuthManager:
         """
         token = self.credential.get_token(scope)
         return _TokenPair(resource=scope, access_token=token.token)
+
+    def acquire_token(self, resource_url: str) -> str:
+        """
+        Acquire an OAuth2 access token for a Microsoft AAD-protected resource.
+
+        Resource-agnostic helper: pass the resource URL (Dataverse env URL
+        for Dataverse, Finance & Operations env URL for F&O, etc.) and the
+        ``/.default`` scope suffix is appended automatically before
+        delegating to the underlying credential. Token caching, refresh,
+        and silent reauthentication are the credential's responsibility;
+        Azure Identity credentials cache in-memory by default so repeated
+        calls are cheap.
+
+        :param resource_url: Resource URL for the target Microsoft service
+            (for example ``"https://myenv.operations.dynamics.com"``).
+            Trailing slash is removed before scope construction.
+        :type resource_url: :class:`str`
+
+        :return: OAuth2 access token string suitable for placing in an
+            ``Authorization: Bearer ...`` header.
+        :rtype: :class:`str`
+
+        :raises ValueError: If ``resource_url`` is empty after trimming.
+        :raises ~azure.core.exceptions.ClientAuthenticationError: If token
+            acquisition fails.
+
+        Example:
+            Acquire a token for a linked Finance & Operations environment
+            using the same credential the Dataverse client was built with::
+
+                client = DataverseClient(dv_url, credential)
+                fno_token = client.auth.acquire_token(
+                    "https://myenv.operations.dynamics.com"
+                )
+        """
+        target = (resource_url or "").rstrip("/")
+        if not target:
+            raise ValueError("resource_url must not be empty.")
+        scope = f"{target}/.default"
+        return self._acquire_token(scope).access_token

--- a/src/PowerPlatform/Dataverse/core/_auth.py
+++ b/src/PowerPlatform/Dataverse/core/_auth.py
@@ -111,7 +111,7 @@ class _AuthManager:
                 fno_token = client.auth.acquire_token(
                     "https://myenv.operations.dynamics.com"
                 )
-        """        
+        """
         target = (resource_url or "").strip().rstrip("/")
         if not target:
             raise ValueError("resource_url must not be empty.")

--- a/src/PowerPlatform/Dataverse/core/_auth.py
+++ b/src/PowerPlatform/Dataverse/core/_auth.py
@@ -6,7 +6,7 @@ Authentication helpers.
 
 This module provides :class:`~PowerPlatform.Dataverse.core._auth._AuthManager`, a thin wrapper over any Azure Identity
 ``TokenCredential`` for acquiring OAuth2 access tokens for Microsoft AAD-protected resources -- Dataverse by default,
-and any other resource (e.g. a linked Finance & Operations environment) when an explicit scope is supplied --
+and any other resource (e.g. a linked ERP environment) when an explicit scope is supplied --
 and :class:`~PowerPlatform.Dataverse.core._auth._TokenPair` for storing the acquired token alongside its scope.
 """
 
@@ -53,7 +53,7 @@ class _AuthManager:
     :meth:`acquire_token`, and the same method can be called externally
     (through ``client.auth.acquire_token(...)``) to obtain tokens for
     other Microsoft AAD-protected resources -- for example a linked
-    Finance & Operations environment.
+    ERP environment (Microsoft Dynamics 365 Finance & Operations).
 
     :param credential: Azure Identity credential implementation.
     :type credential: ~azure.core.credentials.TokenCredential
@@ -83,7 +83,7 @@ class _AuthManager:
         Acquire an OAuth2 access token for a Microsoft AAD-protected resource.
 
         Resource-agnostic helper: pass the resource URL (Dataverse env URL
-        for Dataverse, Finance & Operations env URL for F&O, etc.) and the
+        for Dataverse, ERP env URL for ERP, etc.) and the
         ``/.default`` scope suffix is appended automatically before
         delegating to the underlying credential. Token caching, refresh,
         and silent reauthentication are the credential's responsibility;
@@ -104,7 +104,7 @@ class _AuthManager:
             acquisition fails.
 
         Example:
-            Acquire a token for a linked Finance & Operations environment
+            Acquire a token for a linked ERP environment
             using the same credential the Dataverse client was built with::
 
                 client = DataverseClient(dv_url, credential)

--- a/src/PowerPlatform/Dataverse/core/_auth.py
+++ b/src/PowerPlatform/Dataverse/core/_auth.py
@@ -111,8 +111,8 @@ class _AuthManager:
                 fno_token = client.auth.acquire_token(
                     "https://myenv.operations.dynamics.com"
                 )
-        """
-        target = (resource_url or "").rstrip("/")
+        """        
+        target = (resource_url or "").strip().rstrip("/")
         if not target:
             raise ValueError("resource_url must not be empty.")
         scope = f"{target}/.default"

--- a/src/PowerPlatform/Dataverse/data/_odata.py
+++ b/src/PowerPlatform/Dataverse/data/_odata.py
@@ -94,8 +94,7 @@ class _ODataClient(_FileUploadMixin, _RelationshipOperationsMixin, _ODataBase):
 
     def _headers(self) -> Dict[str, str]:
         """Build standard OData headers with bearer auth."""
-        scope = f"{self.base_url}/.default"
-        token = self.auth._acquire_token(scope).access_token
+        token = self.auth.acquire_token(self.base_url)
         ua = _USER_AGENT
         if self._operation_context:
             ua = f"{_USER_AGENT} ({self._operation_context})"

--- a/src/PowerPlatform/Dataverse/data/_odata.py
+++ b/src/PowerPlatform/Dataverse/data/_odata.py
@@ -62,7 +62,7 @@ class _ODataClient(_FileUploadMixin, _RelationshipOperationsMixin, _ODataBase):
 
         Sets up authentication, base URL, configuration, and internal caches.
 
-        :param auth: Authentication manager providing ``_acquire_token(scope)`` that returns an object with ``access_token``.
+        :param auth: Authentication manager exposing ``acquire_token(resource_url)`` that returns the OAuth2 access token string for the given resource. The internal ``_headers()`` calls ``auth.acquire_token(self.base_url)`` so the token is scoped to this OData client's Dataverse organization.
         :type auth: ~PowerPlatform.Dataverse.core._auth._AuthManager
         :param base_url: Organization base URL (e.g. ``"https://<org>.crm.dynamics.com"``).
         :type base_url: ``str``

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,12 @@ from PowerPlatform.Dataverse.core.config import DataverseConfig
 
 @pytest.fixture
 def dummy_auth():
-    """Mock authentication object for testing."""
+    """Mock authentication object for testing.
+
+    Mirrors the real ``_AuthManager`` surface: both the internal
+    ``_acquire_token(scope)`` (used directly by older tests) and the public
+    ``acquire_token(resource_url)`` (used by ``_ODataClient._headers``).
+    """
 
     class DummyAuth:
         def _acquire_token(self, scope):
@@ -23,6 +28,9 @@ def dummy_auth():
                 access_token = "test_token_12345"
 
             return Token()
+
+        def acquire_token(self, resource_url):
+            return self._acquire_token(f"{(resource_url or '').rstrip('/')}/.default").access_token
 
     return DummyAuth()
 

--- a/tests/unit/core/test_auth.py
+++ b/tests/unit/core/test_auth.py
@@ -34,6 +34,49 @@ class TestAuthManager(unittest.TestCase):
         self.assertEqual(result.resource, "https://org.crm.dynamics.com/.default")
         self.assertEqual(result.access_token, "my-access-token")
 
+    def test_acquire_token_public_appends_default_scope(self):
+        """acquire_token appends /.default to the resource URL and returns the access_token string."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="dv-token")
+
+        manager = _AuthManager(mock_credential)
+        result = manager.acquire_token("https://org.crm.dynamics.com")
+
+        mock_credential.get_token.assert_called_once_with("https://org.crm.dynamics.com/.default")
+        self.assertEqual(result, "dv-token")
+
+    def test_acquire_token_public_strips_trailing_slash(self):
+        """acquire_token strips a trailing slash before constructing the scope."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="t")
+
+        manager = _AuthManager(mock_credential)
+        manager.acquire_token("https://myenv.operations.dynamics.com/")
+
+        mock_credential.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+
+    def test_acquire_token_public_supports_alternate_resource(self):
+        """acquire_token works for any resource URL (e.g. linked Finance & Operations env)."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="fno-token")
+
+        manager = _AuthManager(mock_credential)
+        result = manager.acquire_token("https://myenv.operations.dynamics.com")
+
+        mock_credential.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+        self.assertEqual(result, "fno-token")
+
+    def test_acquire_token_public_empty_url_raises(self):
+        """acquire_token raises ValueError when resource_url is empty after trim and does not call get_token."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        manager = _AuthManager(mock_credential)
+
+        with self.assertRaises(ValueError):
+            manager.acquire_token("")
+        with self.assertRaises(ValueError):
+            manager.acquire_token("/")
+        mock_credential.get_token.assert_not_called()
+
 
 class TestTokenPairReprRedaction(unittest.TestCase):
     """``_TokenPair.__repr__`` must not leak the bearer JWT.

--- a/tests/unit/core/test_auth.py
+++ b/tests/unit/core/test_auth.py
@@ -56,7 +56,7 @@ class TestAuthManager(unittest.TestCase):
         mock_credential.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
 
     def test_acquire_token_public_supports_alternate_resource(self):
-        """acquire_token works for any resource URL (e.g. linked Finance & Operations env)."""
+        """acquire_token works for any resource URL (e.g. linked ERP env)."""
         mock_credential = MagicMock(spec=TokenCredential)
         mock_credential.get_token.return_value = MagicMock(token="fno-token")
 

--- a/tests/unit/core/test_http_errors.py
+++ b/tests/unit/core/test_http_errors.py
@@ -17,6 +17,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):
+        return self._acquire_token(f"{(resource_url or '').rstrip('/')}/.default").access_token
+
 
 class DummyHTTP:
     def __init__(self, responses):

--- a/tests/unit/data/test_enum_optionset_payload.py
+++ b/tests/unit/data/test_enum_optionset_payload.py
@@ -14,6 +14,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):  # pragma: no cover - simple stub
+        return self._acquire_token(f"{(resource_url or '').rstrip('/')}/.default").access_token
+
 
 class DummyConfig:
     """Minimal config stub providing attributes _ODataClient.__init__ expects."""

--- a/tests/unit/data/test_logical_crud.py
+++ b/tests/unit/data/test_logical_crud.py
@@ -14,6 +14,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):
+        return self._acquire_token(f"{(resource_url or '').rstrip('/')}/.default").access_token
+
 
 class DummyHTTPClient:
     def __init__(self, responses):

--- a/tests/unit/data/test_odata_internal.py
+++ b/tests/unit/data/test_odata_internal.py
@@ -3069,5 +3069,37 @@ class TestBuildCreateEntity(unittest.TestCase):
             self.od._build_create_entity("new_TestTable", {"new_Bad": "unsupported_type"})
 
 
+class TestODataClientHeaders(unittest.TestCase):
+    """Regression tests for _ODataClient._headers auth wiring.
+
+    Locks the contract that _headers() delegates token acquisition to
+    ``auth.acquire_token(base_url)`` (the public resource-agnostic entry
+    point) and places the returned token verbatim in the ``Authorization``
+    header. Guards against future refactors silently switching back to
+    ``_acquire_token(scope)`` or to a different scope construction.
+    """
+
+    def test_headers_calls_auth_acquire_token_with_base_url(self):
+        """_headers passes the client's base_url (no /.default suffix) to auth.acquire_token."""
+        base_url = "https://example.crm.dynamics.com"
+        mock_auth = MagicMock()
+        mock_auth.acquire_token.return_value = "tok-abc"
+
+        client = _ODataClient(mock_auth, base_url)
+        client._headers()
+
+        mock_auth.acquire_token.assert_called_once_with(base_url)
+
+    def test_headers_places_token_in_authorization_bearer(self):
+        """_headers uses the string returned by auth.acquire_token as the bearer token."""
+        mock_auth = MagicMock()
+        mock_auth.acquire_token.return_value = "tok-xyz"
+
+        client = _ODataClient(mock_auth, "https://example.crm.dynamics.com")
+        headers = client._headers()
+
+        self.assertEqual(headers["Authorization"], "Bearer tok-xyz")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds `_AuthManager.acquire_token(resource_url)` -- a thin public helper over the existing `_acquire_token`: appends `/.default` and delegates to the underlying `TokenCredential`. Lets callers reuse the same credential to obtain tokens for any Microsoft AAD-protected resource (notably a linked Finance & Operations env) via `client.auth.acquire_token(fno_url)`.
- Refactors internal `_ODataClient._headers()` to call the new method, so the DV and external paths share one scope-construction site (no duplication).
- README, both `SKILL.md` copies, and `CHANGELOG` updated. Inline `DummyAuth` mocks in `conftest.py` and three test modules updated to also expose `acquire_token` so existing `_odata._headers` tests still pass with the refactored call site.

## End-to-end verification

Probe against a real F&O int env using the modified SDK + `AzureCliCredential`:

| Step | Result |
|---|---|
| `client.auth.acquire_token("https://aurorabapenvf94ec.operations.int.dynamics.com")` | Token issued, length 2948 |
| Token `aud` claim (decoded JWT) | `https://aurorabapenvf94ec.operations.int.dynamics.com` (F&O resource, not DV) |
| `GET <fno_url>/data/$metadata` with that token | HTTP 200, ~53 MB of F&O EDMX (`Microsoft.Dynamics.DataEntities` namespace) |

F&O accepted the token. The same code path is taken for DV's own header construction, so the DV experience is unchanged.

## Test plan

- [x] `pytest tests/unit -q` -- 1393 passed (4 new `acquire_token` tests + existing suite)
- [x] `_auth.py` line coverage: 100%
- [x] Manual end-to-end probe against live F&O env (HTTP 200 + correct token audience)
- [x] DV-only flows unchanged (no extra AAD roundtrips; `_headers()` still uses `base_url` from constructor)

## Notes for reviewers

- `client.py` is untouched; the new method lives on `_AuthManager` (single source of truth for scope construction).
- F&O usage is fully opt-in: the SDK never calls `acquire_token` with an F&O URL on its own. Customers explicitly pass the F&O URL when they need it.
- Both `SKILL.md` copies verified byte-identical per the `dataverse-sdk-dev` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)