### PR TITLE
Fix multiple issues in README documentation

### DIFF
--- a/.claude/skills/dataverse-sdk-use/SKILL.md
+++ b/.claude/skills/dataverse-sdk-use/SKILL.md
@@ -430,7 +430,7 @@ relationship = OneToManyRelationshipMetadata(
 )
 
 result = client.tables.create_one_to_many_relationship(lookup, relationship)
-print(f"Created lookup field: {result['lookup_schema_name']}")
+print(f"Created lookup field: {result.lookup_schema_name}")
 ```
 
 #### Create Many-to-Many Relationship
@@ -444,7 +444,7 @@ relationship = ManyToManyRelationshipMetadata(
 )
 
 result = client.tables.create_many_to_many_relationship(relationship)
-print(f"Created: {result['relationship_schema_name']}")
+print(f"Created: {result.relationship_schema_name}")
 ```
 
 #### Convenience Method for Lookup Fields
@@ -463,10 +463,10 @@ result = client.tables.create_lookup_field(
 # Get relationship metadata
 rel = client.tables.get_relationship("new_Department_Employee")
 if rel:
-    print(f"Found: {rel['SchemaName']}")
+    print(f"Found: {rel.relationship_schema_name}")
 
 # Delete relationship
-client.tables.delete_relationship(result["relationship_id"])
+client.tables.delete_relationship(result.relationship_id)
 ```
 
 ### File Operations

--- a/.claude/skills/dataverse-sdk-use/SKILL.md
+++ b/.claude/skills/dataverse-sdk-use/SKILL.md
@@ -592,6 +592,8 @@ except ValidationError as e:
 
 The SDK ships a full async client, `AsyncDataverseClient`, under `PowerPlatform.Dataverse.aio`. Requires the `[async]` extra: `pip install "PowerPlatform-Dataverse-Client[async]"`.
 
+> **Note:** snippets in this section are fragments. Every `await` line assumes it lives inside an `async def main(): ...` body with `client` and `credential` already constructed (see the Client Initialization block for the wrapper). Outside an async function, `await` is a `SyntaxError`.
+
 ### Import
 ```python
 from azure.identity.aio import DefaultAzureCredential
@@ -600,6 +602,8 @@ from PowerPlatform.Dataverse.aio import AsyncDataverseClient
 
 ### Client Initialization
 ```python
+# given: credential constructed (e.g. DefaultAzureCredential())
+
 # Context manager (recommended -- closes session and clears caches automatically)
 async with AsyncDataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
     ...  # all operations here
@@ -615,6 +619,8 @@ finally:
 ### CRUD Operations
 Every sync method has an async equivalent -- add `await`:
 ```python
+# given: client is an open AsyncDataverseClient
+
 # Create
 account_id = await client.records.create("account", {"name": "Contoso Ltd"})
 
@@ -633,6 +639,7 @@ ids = await client.records.create("account", [{"name": "A"}, {"name": "B"}])
 
 ### Query Builder
 ```python
+# given: client is an open AsyncDataverseClient
 from PowerPlatform.Dataverse.models.filters import col
 
 # Collect all results
@@ -666,6 +673,8 @@ rows = await client.query.fetchxml(xml).execute()
 
 ### Batch and Changesets
 ```python
+# given: client is open; account_id from an earlier records.create
+
 # Plain batch
 batch = client.batch.new()
 batch.records.create("account", {"name": "Alpha"})
@@ -681,6 +690,7 @@ result = await batch.execute()
 
 ### DataFrame Operations
 ```python
+# given: client is an open AsyncDataverseClient
 import pandas as pd
 
 # Query to DataFrame

--- a/README.md
+++ b/README.md
@@ -936,24 +936,64 @@ For comprehensive information on Microsoft Dataverse and related technologies:
 
 ## Troubleshooting
 
+### Exception hierarchy
+
+The SDK raises structured exceptions that all inherit from a common base, `DataverseError`. Catching the base class is the safest fallback; catch the specific subclasses when you need to react differently to validation, metadata, SQL, or HTTP failures.
+
+```
+Exception
+└── DataverseError              # Base class for every SDK-raised error
+    ├── ValidationError         # Client-side input validation failed
+    ├── MetadataError           # Table/column/relationship metadata problem
+    ├── SQLParseError           # SQL query could not be parsed
+    └── HttpError               # Dataverse Web API returned a non-success status
+```
+
+All classes are importable from `PowerPlatform.Dataverse.core.errors` (or re-exported from `PowerPlatform.Dataverse.core`).
+
+| Exception | When it is raised | Typical examples |
+|-----------|-------------------|------------------|
+| **`DataverseError`** | Base class. Catch it to handle any SDK-originated failure in one block. | Fallback `except` clause. |
+| **`ValidationError`** | Client-side argument validation fails **before** a request is sent. | Empty/`None` table name, missing primary key, non-string SQL, invalid batch payload, unsupported column type in `create_table`. |
+| **`MetadataError`** | A metadata lookup or definition operation fails — usually an unknown or invalid table, column, or relationship. | Unknown logical name passed to `batch.create/update/delete`, `tables.create_column`, `relationships.create_*`, or `tables.delete`. |
+| **`SQLParseError`** | A SQL string passed to `client.query.sql(...)` cannot be parsed into a valid SELECT. | Unsupported SQL syntax, write statements (`INSERT`/`UPDATE`/`DELETE`), malformed queries. |
+| **`HttpError`** | The Dataverse Web API responded with a non-2xx status. Exposes `status_code`, `service_error_code`, `correlation_id`, `service_request_id`, `retry_after`, and `is_transient` (set for 408/429/503/504). | 401 (auth), 403 (permissions), 404 (record/table not found), 412 (concurrency/ETag), 429 (throttling), 5xx (server). |
+
+> **Note on timeouts and network errors.** Low-level network failures from the underlying `httpx` client are **not** wrapped by the SDK and surface as their original `httpx` exceptions — most commonly `httpx.ReadTimeout`, `httpx.ConnectTimeout`, and `httpx.TimeoutException` (their common base) on slow endpoints such as `relationships.list()` or large queries, and `httpx.ConnectError`/`httpx.NetworkError` for connectivity issues. Catch `httpx.HTTPError` to cover all of them, or `httpx.TimeoutException` for timeouts specifically. The async client (`PowerPlatform.Dataverse.aio`) surfaces `aiohttp.ClientError` and `asyncio.TimeoutError` analogously.
+
 ### General
 
-The client raises structured exceptions for different error scenarios:
-
 ```python
+import httpx
 from PowerPlatform.Dataverse.client import DataverseClient
-from PowerPlatform.Dataverse.core.errors import HttpError, ValidationError
+from PowerPlatform.Dataverse.core.errors import (
+    DataverseError,
+    HttpError,
+    MetadataError,
+    SQLParseError,
+    ValidationError,
+)
 
 try:
     client.records.retrieve("account", "invalid-id")
+except ValidationError as e:
+    print(f"Validation error: {e.message} (subcode={e.subcode})")
+except MetadataError as e:
+    print(f"Metadata error: {e.message} (subcode={e.subcode})")
+except SQLParseError as e:
+    print(f"SQL parse error: {e.message}")
 except HttpError as e:
     print(f"HTTP {e.status_code}: {e.message}")
-    print(f"Error code: {e.code}")
-    print(f"Subcode: {e.subcode}")
+    print(f"Code: {e.code}  Subcode: {e.subcode}")
+    print(f"Service request id: {e.details.get('service_request_id')}")
     if e.is_transient:
-        print("This error may be retryable")
-except ValidationError as e:
-    print(f"Validation error: {e.message}")
+        print(f"Transient — retry after {e.details.get('retry_after')}s")
+except httpx.TimeoutException as e:
+    # ReadTimeout / ConnectTimeout / WriteTimeout from the underlying transport
+    print(f"Request timed out: {e}")
+except DataverseError as e:
+    # Catch-all for any other SDK-raised error
+    print(f"Dataverse error [{e.code}]: {e.message}")
 ```
 
 ### Authentication issues

--- a/README.md
+++ b/README.md
@@ -839,10 +839,13 @@ pip install "PowerPlatform-Dataverse-Client[async]"
 
 ```python
 import asyncio
-from azure.identity.aio import DefaultAzureCredential
+from azure.identity import InteractiveBrowserCredential
 from PowerPlatform.Dataverse.aio import AsyncDataverseClient
 
 async def main():
+    # Connect to Dataverse
+    credential = InteractiveBrowserCredential()
+
     async with DefaultAzureCredential() as credential:
         async with AsyncDataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
             # Create a contact

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ relationship = OneToManyRelationshipMetadata(
 )
 
 result = client.tables.create_one_to_many_relationship(lookup, relationship)
-print(f"Created lookup field: {result['lookup_schema_name']}")
+print(f"Created lookup field: {result.lookup_schema_name}")
 
 # Create a many-to-many relationship: Employee (N) <-> Project (N)
 # Employees work on multiple projects; projects have multiple team members
@@ -676,12 +676,12 @@ m2m_relationship = ManyToManyRelationshipMetadata(
 )
 
 result = client.tables.create_many_to_many_relationship(m2m_relationship)
-print(f"Created M:N relationship: {result['relationship_schema_name']}")
+print(f"Created M:N relationship: {result.relationship_schema_name}")
 
 # Query relationship metadata
 rel = client.tables.get_relationship("new_Department_Employee")
 if rel:
-    print(f"Found: {rel['SchemaName']}")
+    print(f"Found: {rel.relationship_schema_name}")
 
 # List all relationships
 rels = client.tables.list_relationships()
@@ -694,7 +694,7 @@ for rel in account_rels:
     print(f"{rel['SchemaName']} -> {rel.get('RelationshipType')}")
 
 # Delete a relationship
-client.tables.delete_relationship(result['relationship_id'])
+client.tables.delete_relationship(result.relationship_id)
 ```
 
 For simpler scenarios, use the convenience method:

--- a/README.md
+++ b/README.md
@@ -486,10 +486,14 @@ results = (client.query.builder("account")
            .where(col("statecode") == 0)
            .count()
            .execute())
+print(len(results))   # QueryResult is sized — use len() to get the count
 
 # Via records.list() — count=True adds $count=true to the OData request
 results = client.records.list("account", filter="statecode eq 0", count=True)
+print(len(results))
 ```
+
+> **Accessing the count:** `QueryResult` is iterable and sized — call `len(results)` to get the number of records. There is no separate `.count` or `.total_count` attribute. Because the client auto-paginates, `len(results)` reflects every matching row fetched; the server's raw `@odata.count` annotation is not surfaced as a standalone field.
 
 **FetchXML queries** -- `client.query.fetchxml()` returns an inert `FetchXmlQuery` object; no HTTP request is made until you call `.execute()` or `.execute_pages()`:
 

--- a/README.md
+++ b/README.md
@@ -825,6 +825,8 @@ For a complete example see [examples/advanced/batch.py](https://github.com/micro
 
 The SDK ships a full async client, `AsyncDataverseClient`, for use in async applications. It mirrors every operation of the sync client — the same namespaces (`records`, `query`, `tables`, `files`, `batch`), the same method signatures, and the same return types.
 
+> ⓘ **Async snippets below are fragments.** Every example after `### Quick start` assumes it is nested inside an `async def main(): ...` body, with `client` and `credential` already constructed as shown in Quick start. Copying a fragment into a top-level `.py` file will raise `SyntaxError: 'await' outside function`. See [examples/aio/](https://github.com/microsoft/PowerPlatform-DataverseClient-Python/tree/main/examples/aio) for full runnable scripts.
+
 ### Install
 
 The async client requires `aiohttp`, which is an optional extra:
@@ -859,6 +861,7 @@ asyncio.run(main())
 ### Standalone usage (without `async with`)
 
 ```python
+# given: credential constructed as in Quick start (e.g. DefaultAzureCredential())
 client = AsyncDataverseClient("https://yourorg.crm.dynamics.com", credential)
 try:
     account_id = await client.records.create("account", {"name": "Contoso Ltd"})
@@ -871,6 +874,7 @@ finally:
 The async query builder API is identical to the sync one:
 
 ```python
+# given: client is an open AsyncDataverseClient
 from PowerPlatform.Dataverse.models.filters import col
 
 # Execute and collect all results
@@ -898,6 +902,7 @@ async for page in (
 ### Batch and changesets
 
 ```python
+# given: client is open; account_id is the GUID returned by an earlier records.create
 batch = client.batch.new()
 batch.records.create("account", {"name": "Alpha"})
 batch.records.create("account", {"name": "Beta"})

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ payloads = [
 ids = client.records.create("account", payloads)
 
 # Bulk update (broadcast same change to all)
-client.records.update("account", ids, {"industry": "Technology"})
+client.records.update("account", ids, {"exchangerate": 1})
 
 # Bulk delete
 client.records.delete("account", ids, use_bulk_delete=True)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ client.records.update("account", account_id, {"telephone1": "555-0199"})
 client.records.delete("account", account_id)
 ```
 
+> **Deprecation note (migration from beta):** `client.records.get()` is deprecated and emits a `DeprecationWarning`. Use `client.records.retrieve(table, record_id)` for single-record reads (returns `None` on 404 instead of raising) and `client.records.list(table, filter=...)` / `client.records.list_pages(...)` for multi-record queries. Return types differ from the beta `get()`, so the codemod flags these for manual review rather than rewriting them — run `dataverse-migrate` (see [Query data](#query-data)) to locate every call site.
+
 ### Bulk operations
 
 ```python

--- a/README.md
+++ b/README.md
@@ -786,6 +786,13 @@ for item in result.failed:
     print(f"[ERR] {item.status_code}: {item.error_message}")
 ```
 
+> `continue_on_error=True` only affects how Dataverse handles per-operation
+> failures on the server. Client-side errors raised before the batch is sent
+> — such as `ValidationError` (e.g. exceeding the 1000-operation limit) or
+> `MetadataError` from metadata pre-resolution (`tables.delete`,
+> `tables.add_columns`, `tables.remove_columns`) — are still raised as
+> exceptions and must be handled with `try`/`except`.
+
 **DataFrame integration** -- feed pandas DataFrames directly into a batch:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -689,12 +689,12 @@ if rel:
 # List all relationships
 rels = client.tables.list_relationships()
 for rel in rels:
-    print(f"{rel['SchemaName']} ({rel.get('@odata.type')})")
+    print(f"{rel['SchemaName']} ({rel.get('RelationshipType')})")
 
 # List relationships for a specific table (one-to-many + many-to-one + many-to-many)
 account_rels = client.tables.list_table_relationships("account")
 for rel in account_rels:
-    print(f"{rel['SchemaName']} -> {rel.get('@odata.type')}")
+    print(f"{rel['SchemaName']} -> {rel.get('RelationshipType')}")
 
 # Delete a relationship
 client.tables.delete_relationship(result['relationship_id'])

--- a/README.md
+++ b/README.md
@@ -104,14 +104,19 @@ from PowerPlatform.Dataverse.client import DataverseClient
 credential = InteractiveBrowserCredential()  # Browser authentication
 # credential = AzureCliCredential()          # If logged in via 'az login'
 
-# Production options
-# credential = ClientSecretCredential(tenant_id, client_id, client_secret)
+# For Production options (service principal / app-only auth)
+# credential = ClientSecretCredential(
+#     tenant_id="...",      # ID of the service principal's tenant. Also called its "directory" ID.
+#     client_id="...",      # The service principal's client ID
+#     client_secret="...",  # Client secret value generated for the app (store in Key Vault / env var)
+# )
 # credential = CertificateCredential(tenant_id, client_id, cert_path)
 
 client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 ```
+Ref: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity?view=azure-python
 
-> **Complete authentication setup**: See **[Use OAuth with Dataverse](https://learn.microsoft.com/power-apps/developer/data-platform/authenticate-oauth)** for app registration, all credential types, and security configuration.
+> **Set up service principal authentication**: To use `ClientSecretCredential` or `CertificateCredential` you must first register an Azure AD app and grant it access to your Dataverse environment as an application user. See **[Use OAuth with Dataverse](https://learn.microsoft.com/power-apps/developer/data-platform/authenticate-oauth)** (covers app registration, obtaining `tenant_id` / `client_id` / `client_secret`, all credential types, and security configuration).
 
 ## Key concepts
 

--- a/README.md
+++ b/README.md
@@ -360,12 +360,9 @@ print(f"Got {len(df)} accounts")
 ```python
 # Comparison filters using col() expressions
 query = (client.query.builder("contact")
-         .where(col("statecode") == 0)                        # statecode eq 0
-         .where(col("revenue") > 1000000)                     # revenue gt 1000000
-         .where(col("name").contains("Corp"))                 # contains(name, 'Corp')
-         .where(col("statecode").in_([0, 1]))                 # Microsoft.Dynamics.CRM.In(...)
-         .where(col("revenue").between(100000, 500000))       # revenue ge 100000 and revenue le 500000
-         .where(col("telephone1").is_null())                  # telephone1 eq null
+         .where(col("email").contains("outlook.com"))       # contains(email from domain, 'outlook.com')
+         .where(col("creditlimit").between(10000, 50000))   # credit limit ge 10000 and revenue le 50000
+         .where(col("telephone1").is_null())                # telephone1 eq null
          )
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,26 @@ a PATCH request; multiple items use the `UpsertMultiple` bulk action.
 > maker portal → Table → Keys, or via the Dataverse API). Without a configured alternate key,
 > upsert requests will be rejected by Dataverse with a 400 error.
 
+Set up the key once before running the upsert examples:
+
+```python
+# One-time setup for the examples below: make accountnumber an alternate key on account
+key = client.tables.create_alternate_key(
+    "account",
+    "account_accountnumber_ak",
+    ["accountnumber"],
+    display_name="Account Number",
+)
+print(f"Created key {key.schema_name} ({key.metadata_id}), status={key.status}")
+
+# Optional: check key status (useful right after creation; status transitions Pending -> Active)
+for k in client.tables.get_alternate_keys("account"):
+    if k.schema_name == "account_accountnumber_ak":
+        print(f"{k.schema_name}: {k.status}")
+```
+
+Upsert usage
+
 ```python
 from PowerPlatform.Dataverse.models import UpsertItem
 

--- a/src/PowerPlatform/Dataverse/aio/operations/async_tables.py
+++ b/src/PowerPlatform/Dataverse/aio/operations/async_tables.py
@@ -561,7 +561,7 @@ class AsyncTableOperations:
                     required=True,
                     cascade_delete=CASCADE_BEHAVIOR_REMOVE_LINK,
                 )
-                print(f"Created lookup: {result['lookup_schema_name']}")
+                print(f"Created lookup: {result.lookup_schema_name}")
         """
         async with self._client._scoped_odata() as od:
             lookup, relationship = od._build_lookup_field_models(

--- a/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
+++ b/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
@@ -430,7 +430,7 @@ relationship = OneToManyRelationshipMetadata(
 )
 
 result = client.tables.create_one_to_many_relationship(lookup, relationship)
-print(f"Created lookup field: {result['lookup_schema_name']}")
+print(f"Created lookup field: {result.lookup_schema_name}")
 ```
 
 #### Create Many-to-Many Relationship
@@ -444,7 +444,7 @@ relationship = ManyToManyRelationshipMetadata(
 )
 
 result = client.tables.create_many_to_many_relationship(relationship)
-print(f"Created: {result['relationship_schema_name']}")
+print(f"Created: {result.relationship_schema_name}")
 ```
 
 #### Convenience Method for Lookup Fields
@@ -463,10 +463,10 @@ result = client.tables.create_lookup_field(
 # Get relationship metadata
 rel = client.tables.get_relationship("new_Department_Employee")
 if rel:
-    print(f"Found: {rel['SchemaName']}")
+    print(f"Found: {rel.relationship_schema_name}")
 
 # Delete relationship
-client.tables.delete_relationship(result["relationship_id"])
+client.tables.delete_relationship(result.relationship_id)
 ```
 
 ### File Operations

--- a/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
+++ b/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
@@ -592,6 +592,8 @@ except ValidationError as e:
 
 The SDK ships a full async client, `AsyncDataverseClient`, under `PowerPlatform.Dataverse.aio`. Requires the `[async]` extra: `pip install "PowerPlatform-Dataverse-Client[async]"`.
 
+> **Note:** snippets in this section are fragments. Every `await` line assumes it lives inside an `async def main(): ...` body with `client` and `credential` already constructed (see the Client Initialization block for the wrapper). Outside an async function, `await` is a `SyntaxError`.
+
 ### Import
 ```python
 from azure.identity.aio import DefaultAzureCredential
@@ -600,6 +602,8 @@ from PowerPlatform.Dataverse.aio import AsyncDataverseClient
 
 ### Client Initialization
 ```python
+# given: credential constructed (e.g. DefaultAzureCredential())
+
 # Context manager (recommended -- closes session and clears caches automatically)
 async with AsyncDataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
     ...  # all operations here
@@ -615,6 +619,8 @@ finally:
 ### CRUD Operations
 Every sync method has an async equivalent -- add `await`:
 ```python
+# given: client is an open AsyncDataverseClient
+
 # Create
 account_id = await client.records.create("account", {"name": "Contoso Ltd"})
 
@@ -633,6 +639,7 @@ ids = await client.records.create("account", [{"name": "A"}, {"name": "B"}])
 
 ### Query Builder
 ```python
+# given: client is an open AsyncDataverseClient
 from PowerPlatform.Dataverse.models.filters import col
 
 # Collect all results
@@ -666,6 +673,8 @@ rows = await client.query.fetchxml(xml).execute()
 
 ### Batch and Changesets
 ```python
+# given: client is open; account_id from an earlier records.create
+
 # Plain batch
 batch = client.batch.new()
 batch.records.create("account", {"name": "Alpha"})
@@ -681,6 +690,7 @@ result = await batch.execute()
 
 ### DataFrame Operations
 ```python
+# given: client is an open AsyncDataverseClient
 import pandas as pd
 
 # Query to DataFrame

--- a/src/PowerPlatform/Dataverse/operations/tables.py
+++ b/src/PowerPlatform/Dataverse/operations/tables.py
@@ -562,7 +562,7 @@ class TableOperations:
                     required=True,
                     cascade_delete=CASCADE_BEHAVIOR_REMOVE_LINK,
                 )
-                print(f"Created lookup: {result['lookup_schema_name']}")
+                print(f"Created lookup: {result.lookup_schema_name}")
         """
         with self._client._scoped_odata() as od:
             lookup, relationship = od._build_lookup_field_models(


### PR DESCRIPTION
This pull request significantly improves the documentation for the Dataverse Python SDK, focusing on clearer authentication setup, improved async usage guidance, enhanced exception handling documentation, and more accurate and idiomatic code examples. The changes help new and existing users better understand both basic and advanced SDK usage, error handling, and recommended best practices.

**Authentication and credential setup:**
- Expanded and clarified instructions for production authentication, including detailed comments and links for setting up `ClientSecretCredential` and `CertificateCredential`, and emphasized the need to register an Azure AD application and configure permissions.
- Added a reference link to the Azure Identity documentation for further guidance.

**Async client usage and documentation:**
- Added notes and code comments throughout the async sections in both `README.md` and `.claude/skills/dataverse-sdk-use/SKILL.md` to clarify that async code fragments require an `async def main()` context, and that `await` cannot be used at the top level. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R828-R829) [[2]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R595-R596) [[3]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R605-R606) [[4]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R622-R623) [[5]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R642) [[6]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R676-R677) [[7]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R693)
- Updated async code snippets to show proper credential instantiation and improved context management examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L805-R848) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R867) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R880) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R908)

**Exception handling and troubleshooting:**
- Added a comprehensive section detailing the SDK's exception hierarchy, including a diagram and table explaining when each error type is raised and how to handle them. Provided explicit examples for handling `ValidationError`, `MetadataError`, `SQLParseError`, `HttpError`, and network errors (`httpx`/`aiohttp`).
- Clarified that `continue_on_error` in batch operations only affects server-side failures, not client-side validation or metadata errors.

**Code correctness and idiomatic usage:**
- Updated all relationship and metadata access in code examples to use attribute access (e.g., `result.lookup_schema_name`) instead of dictionary-style access, reflecting the actual SDK API and improving code reliability. [[1]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43L433-R433) [[2]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43L447-R447) [[3]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43L466-R469) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L642-R670) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L653-R699)
- Improved and corrected query builder examples to use realistic and relevant fields, such as using `email` and `creditlimit` instead of deprecated or less common fields.

**Bulk and upsert operations:**
- Added a new section with code for setting up alternate keys before performing upsert operations, clarifying the one-time setup required and how to check key status.
- Updated bulk update examples to use the correct field (`exchangerate`) and improved comments for clarity.

These changes collectively make the documentation more accurate, user-friendly, and robust for both synchronous and asynchronous SDK usage.

**References:**  
[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R119) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R219-R238) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L338-R366) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L642-R670) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L653-R699) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R791-R797) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R828-R829) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L805-R848) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R867) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R880) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R908) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L914-R1014) [[13]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43L433-R433) [[14]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43L447-R447) [[15]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43L466-R469) [[16]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R595-R596) [[17]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R605-R606) [[18]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R622-R623) [[19]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R642) [[20]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R676-R677) [[21]](diffhunk://#diff-6f4933cbfbc3901b4a43d1472b528be4b812e2f07175f18c5b5fe8bbcaef5d43R693)