### PR TITLE
Bug bash fixes: Add QueryResult.__aiter__ for async (ADO 6431066)

### DIFF
--- a/examples/aio/advanced/walkthrough.py
+++ b/examples/aio/advanced/walkthrough.py
@@ -265,6 +265,16 @@ async def _run_walkthrough(client):
         record_ids = [r.get("new_walkthroughdemoid")[:8] + "..." for r in page]
         print(f"  Page {page_num}: {len(page)} records - IDs: {record_ids}")
 
+    log_call(
+        "async for record in await client.query.builder(...).top(5).execute()  — QueryResult supports async iteration"
+    )
+    print("Iterating a QueryResult with `async for` (top 5 by quantity)...")
+    top_result = await backoff(
+        lambda: client.query.builder(table_name).order_by("new_Quantity", descending=True).top(5).execute()
+    )
+    async for record in top_result:
+        print(f"  - Qty={record.get('new_quantity')} Title={record.get('new_title')}")
+
     # ============================================================================
     # 7. QUERYBUILDER - FLUENT QUERIES
     # ============================================================================

--- a/src/PowerPlatform/Dataverse/models/record.py
+++ b/src/PowerPlatform/Dataverse/models/record.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, KeysView, List, Optional, Union, ValuesView, ItemsView
+from typing import Any, AsyncIterator, Dict, Iterator, KeysView, List, Optional, Union, ValuesView, ItemsView
 
 __all__ = ["Record", "QueryResult"]
 
@@ -131,6 +131,10 @@ class QueryResult:
 
     def __iter__(self) -> Iterator[Record]:
         return iter(self.records)
+
+    async def __aiter__(self) -> AsyncIterator[Record]:
+        for record in self.records:
+            yield record
 
     def __len__(self) -> int:
         return len(self.records)

--- a/tests/unit/aio/test_async_query.py
+++ b/tests/unit/aio/test_async_query.py
@@ -529,3 +529,35 @@ class TestAsyncFetchXmlQueryPaging:
             warnings.simplefilter("always")
             with pytest.raises(ValidationError, match="exceeded"):
                 await async_client.query.fetchxml(_SIMPLE_FETCHXML).execute()
+
+
+class TestQueryResultAsyncIteration:
+    """QueryResult must support ``async for`` so callers can write
+    ``async for r in page`` after ``async for page in q.execute_pages()``.
+    """
+
+    def _records(self, n=3):
+        return [Record(id=f"id-{i}", table="account", data={"name": f"R{i}"}) for i in range(n)]
+
+    async def test_has_aiter(self):
+        qr = QueryResult(self._records())
+        assert hasattr(qr, "__aiter__")
+
+    async def test_async_for_yields_all_records(self):
+        qr = QueryResult(self._records(3))
+        result = [r async for r in qr]
+        assert len(result) == 3
+        assert [r["name"] for r in result] == ["R0", "R1", "R2"]
+
+    async def test_async_for_empty(self):
+        qr = QueryResult([])
+        result = [r async for r in qr]
+        assert result == []
+
+    async def test_sync_and_async_return_same_records(self):
+        qr = QueryResult(self._records(5))
+        sync_result = list(qr)
+        async_result = [r async for r in qr]
+        assert len(sync_result) == len(async_result)
+        for s, a in zip(sync_result, async_result):
+            assert s is a


### PR DESCRIPTION
## Summary
Fixes [ADO 6431066](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/6431066): `QueryResult` could not be consumed with `async for`, breaking the natural iteration pattern in async code.

## Problem
`QueryResult` defined only `__iter__`. Python's `async for` does **not** fall back to a sync `__iter__`, so:

```python
async for record in await client.query.fetchxml(fx).execute():
    ...