### PR TITLE
Fix create table ignoring solution parameter: send MSCRM.SolutionUniqueName header

### DIFF
--- a/src/PowerPlatform/Dataverse/aio/data/_async_odata.py
+++ b/src/PowerPlatform/Dataverse/aio/data/_async_odata.py
@@ -862,10 +862,10 @@ class _AsyncODataClient(_AsyncFileUploadMixin, _AsyncRelationshipOperationsMixin
                 }
             ]
         }
-        params = None
+        headers = None
         if solution_unique_name:
-            params = {"SolutionUniqueName": solution_unique_name}
-        await self._request("post", url, json=payload, params=params)
+            headers = {"MSCRM.SolutionUniqueName": solution_unique_name}
+        await self._request("post", url, json=payload, headers=headers)
         ent = await self._get_entity_by_table_schema_name(
             table_schema_name,
             headers={"Consistency": "Strong"},

--- a/src/PowerPlatform/Dataverse/data/_odata.py
+++ b/src/PowerPlatform/Dataverse/data/_odata.py
@@ -841,10 +841,10 @@ class _ODataClient(_FileUploadMixin, _RelationshipOperationsMixin, _ODataBase):
                 }
             ]
         }
-        params = None
+        headers = None
         if solution_unique_name:
-            params = {"SolutionUniqueName": solution_unique_name}
-        self._request("post", url, json=payload, params=params)
+            headers = {"MSCRM.SolutionUniqueName": solution_unique_name}
+        self._request("post", url, json=payload, headers=headers)
         ent = self._get_entity_by_table_schema_name(
             table_schema_name,
             headers={"Consistency": "Strong"},

--- a/src/PowerPlatform/Dataverse/data/_odata_base.py
+++ b/src/PowerPlatform/Dataverse/data/_odata_base.py
@@ -604,12 +604,14 @@ class _ODataBase:
             ]
         }
         url = f"{self.api}/CreateEntities"
+        headers: Optional[Dict[str, str]] = None
         if solution:
-            url += f"?SolutionUniqueName={solution}"
+            headers = {"MSCRM.SolutionUniqueName": solution}
         return _RawRequest(
             method="POST",
             url=url,
             body=json.dumps(body, ensure_ascii=False),
+            headers=headers,
         )
 
     def _build_delete_entity(self, metadata_id: str) -> _RawRequest:

--- a/tests/unit/aio/data/test_async_odata_internal.py
+++ b/tests/unit/aio/data/test_async_odata_internal.py
@@ -1700,7 +1700,7 @@ class TestCreateEntityEdgeCases:
     """Coverage for _create_entity() solution_name, missing EntitySetName, missing MetadataId."""
 
     async def test_create_entity_with_solution_unique_name(self):
-        """solution_unique_name is passed as a query parameter to the POST request."""
+        """solution_unique_name is passed as the MSCRM.SolutionUniqueName header on the POST request."""
         client = _make_client()
         client._request.return_value = _resp(status=204)
         entity_resp = {
@@ -1718,7 +1718,7 @@ class TestCreateEntityEdgeCases:
             solution_unique_name="MySolution",
         )
         _, kwargs = client._request.call_args
-        assert kwargs.get("params", {}).get("SolutionUniqueName") == "MySolution"
+        assert kwargs.get("headers", {}).get("MSCRM.SolutionUniqueName") == "MySolution"
         assert result["EntitySetName"] == "new_tables"
 
     async def test_create_entity_missing_entity_set_name_raises(self):

--- a/tests/unit/data/test_odata_internal.py
+++ b/tests/unit/data/test_odata_internal.py
@@ -1338,12 +1338,12 @@ class TestCreateEntity(unittest.TestCase):
             self.od._create_entity("new_TestTable", "Test Table", [])
         self.assertIn("MetadataId missing", str(ctx.exception))
 
-    def test_solution_unique_name_passed_as_param(self):
-        """_create_entity passes SolutionUniqueName as query param when provided."""
+    def test_solution_unique_name_passed_as_header(self):
+        """_create_entity passes MSCRM.SolutionUniqueName header when provided."""
         self._setup_entity_creation()
         self.od._create_entity("new_TestTable", "Test Table", [], solution_unique_name="MySolution")
         post_call = next(c for c in self.od._request.call_args_list if c.args[0] == "post")
-        self.assertEqual(post_call.kwargs.get("params"), {"SolutionUniqueName": "MySolution"})
+        self.assertEqual(post_call.kwargs.get("headers"), {"MSCRM.SolutionUniqueName": "MySolution"})
 
 
 class TestGetAttributeMetadata(unittest.TestCase):
@@ -2994,10 +2994,11 @@ class TestBuildCreateEntity(unittest.TestCase):
         req = self.od._build_create_entity("new_TestTable", {})
         self.assertTrue(req.url.endswith("/CreateEntities"))
 
-    def test_solution_appended_to_url(self):
-        """_build_create_entity appends SolutionUniqueName to URL when solution is given."""
+    def test_solution_passed_as_header(self):
+        """_build_create_entity sets MSCRM.SolutionUniqueName header when solution is given."""
         req = self.od._build_create_entity("new_TestTable", {}, solution="MySolution")
-        self.assertIn("SolutionUniqueName=MySolution", req.url)
+        self.assertEqual(req.headers, {"MSCRM.SolutionUniqueName": "MySolution"})
+        self.assertNotIn("SolutionUniqueName", req.url)
 
     def test_no_solution_no_query_string(self):
         """_build_create_entity URL has no query string when solution is omitted."""


### PR DESCRIPTION
**Problem**
`create_table` with `solution=` sent `SolutionUniqueName` as a URL query parameter on the `CreateEntities` action. Dataverse ignores unknown query options, so the request succeeded but the table always landed in the Default solution.

**Fix**
Send the documented `MSCRM.SolutionUniqueName` request header instead (same mechanism relationship creation already uses) in sync, async, and batch code paths. Updated the 3 unit tests that asserted the query-param behavior.

Ref: https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/create-update-entity-definitions-using-web-api