### PR TITLE
Add acquire_token() for cross-resource auth (sync + async) - supersedes #182

### DIFF
--- a/.claude/skills/dataverse-sdk-use/SKILL.md
+++ b/.claude/skills/dataverse-sdk-use/SKILL.md
@@ -79,6 +79,24 @@ with DataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
 client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 ```
 
+### Acquiring Tokens for Other Microsoft Resources
+
+`client.auth.acquire_token(resource_url)` returns an OAuth2 access token from the **same credential** for any Microsoft Entra ID protected resource — for example a linked Dynamics 365 Finance & Operations environment. Use it instead of building a second credential. The `/.default` scope is appended automatically.
+
+```python
+# Sync client
+fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
+
+# Use the token to call the ERP OData / Custom Service endpoints directly
+headers = {"Authorization": f"Bearer {fno_token}"}
+
+# Async client
+async with AsyncDataverseClient("https://yourorg.crm.dynamics.com", credential) as aclient:
+    fno_token = await aclient.auth.acquire_token("https://myenv.operations.dynamics.com")
+```
+
+Pass the bare resource URL — trailing slashes and surrounding whitespace are trimmed, and a blank value raises `ValueError`. The app registration must already hold the required permission on the target resource with admin consent granted. For Finance & Operations the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+
 ### CRUD Operations
 
 #### Create Records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Cross-resource token acquisition** — `client.auth.acquire_token(resource_url)` (and `await client.auth.acquire_token(resource_url)` on `AsyncDataverseClient`) returns an OAuth2 access token for any Microsoft Entra ID protected resource using the same credential the Dataverse client was constructed with — for example a linked Dynamics 365 Finance & Operations environment. The `/.default` scope is appended automatically; token caching and refresh remain the credential's responsibility. The internal Dataverse request path now routes through the same method, removing the duplicated inline scope construction in `_ODataClient._headers()` and `_AsyncODataClient._headers()`.
+
 ## [1.0.0] - 2026-05-28
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Python client library for Microsoft Dataverse that provides a unified interfac
   - [Prerequisites](#prerequisites)
   - [Install the package](#install-the-package)
   - [Authenticate the client](#authenticate-the-client)
+    - [Acquire tokens for other Microsoft resources](#acquire-tokens-for-other-microsoft-resources)
 - [Key concepts](#key-concepts)
 - [Examples](#examples)
   - [Quick start](#quick-start)
@@ -114,6 +115,28 @@ client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 Ref: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity?view=azure-python
 
 > **Set up service principal authentication**: To use `ClientSecretCredential` or `CertificateCredential` you must first register an Azure AD app and grant it access to your Dataverse environment as an application user. See **[Use OAuth with Dataverse](https://learn.microsoft.com/power-apps/developer/data-platform/authenticate-oauth)** (covers app registration, obtaining `tenant_id` / `client_id` / `client_secret`, all credential types, and security configuration).
+
+#### Acquire tokens for other Microsoft resources
+
+The credential you already gave the client can also mint tokens for **other Microsoft Entra ID protected resources** — most commonly a linked Dynamics 365 Finance & Operations environment that sits alongside the same Dataverse org. Use `client.auth.acquire_token(resource_url)` instead of constructing a second credential:
+
+```python
+# Sync client
+fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
+
+headers = {"Authorization": f"Bearer {fno_token}"}
+# Call the ERP OData / Custom Service endpoints directly with `requests`, `httpx`, ...
+```
+
+```python
+# Async client
+async with AsyncDataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
+    fno_token = await client.auth.acquire_token("https://myenv.operations.dynamics.com")
+```
+
+The `/.default` scope is appended automatically, so pass the bare resource URL (trailing slashes and surrounding whitespace are trimmed; a blank value raises `ValueError`). Token caching and refresh remain the credential's responsibility — Azure Identity credentials cache in memory, so repeated calls are cheap.
+
+The app registration must already hold the required permission on the target resource, with admin consent granted. For Finance & Operations the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
 
 ## Key concepts
 

--- a/src/PowerPlatform/Dataverse/aio/core/_async_auth.py
+++ b/src/PowerPlatform/Dataverse/aio/core/_async_auth.py
@@ -6,20 +6,30 @@ Async authentication helpers for Dataverse.
 
 This module provides :class:`~PowerPlatform.Dataverse.aio.core._async_auth._AsyncAuthManager`,
 a thin wrapper over any Azure Identity ``AsyncTokenCredential`` for acquiring OAuth2 access
-tokens asynchronously, and reuses :class:`~PowerPlatform.Dataverse.core._auth._TokenPair` for
-storing the acquired token alongside its scope.
+tokens asynchronously for Microsoft Entra ID protected resources -- Dataverse by default, and
+any other resource (for example a linked Dynamics 365 Finance & Operations environment) when a
+different resource URL is supplied -- and reuses
+:class:`~PowerPlatform.Dataverse.core._auth._TokenPair` for storing the acquired token alongside
+its scope.
 """
 
 from __future__ import annotations
 
 from azure.core.credentials_async import AsyncTokenCredential
 
-from ...core._auth import _TokenPair
+from ...core._auth import _TokenPair, _build_default_scope
 
 
 class _AsyncAuthManager:
     """
-    Azure Identity-based async authentication manager for Dataverse.
+    Azure Identity-based async authentication manager.
+
+    Async counterpart to :class:`~PowerPlatform.Dataverse.core._auth._AuthManager` with the same
+    resource-agnostic surface: the resource URL passed to :meth:`acquire_token` selects the target
+    resource. The async Dataverse client supplies its own organization URL on every internal
+    request, and the same method can be awaited by application code (through
+    ``await client.auth.acquire_token(...)``) to obtain tokens for other Microsoft Entra ID
+    protected resources -- for example a linked Dynamics 365 Finance & Operations environment.
 
     :param credential: Azure Identity async credential implementation.
     :type credential: ~azure.core.credentials_async.AsyncTokenCredential
@@ -43,3 +53,34 @@ class _AsyncAuthManager:
         """
         token = await self.credential.get_token(scope)
         return _TokenPair(resource=scope, access_token=token.token)
+
+    async def acquire_token(self, resource_url: str) -> str:
+        """
+        Acquire an OAuth2 access token asynchronously for a Microsoft Entra ID protected resource.
+
+        Async counterpart of :meth:`~PowerPlatform.Dataverse.core._auth._AuthManager.acquire_token`.
+        Resource-agnostic helper: pass the resource URL (the Dataverse environment URL for
+        Dataverse, the Finance & Operations environment URL for ERP, and so on) and the
+        ``/.default`` scope suffix is appended automatically before delegating to the underlying
+        credential. Token caching, refresh, and silent reauthentication remain the credential's
+        responsibility; Azure Identity credentials cache in memory by default, so repeated calls
+        are cheap.
+
+        :param resource_url: Resource URL for the target Microsoft service (for example
+            ``"https://myenv.operations.dynamics.com"``). Surrounding whitespace and trailing
+            slashes are removed before scope construction.
+        :type resource_url: :class:`str`
+        :return: OAuth2 access token string suitable for an ``Authorization: Bearer <token>`` header.
+        :rtype: :class:`str`
+        :raises ValueError: If ``resource_url`` is empty after trimming whitespace and trailing slashes.
+        :raises ~azure.core.exceptions.ClientAuthenticationError: If token acquisition fails.
+
+        Example:
+            Acquire a token for a linked Finance & Operations environment using the same credential
+            the async Dataverse client was built with::
+
+                async with AsyncDataverseClient(dataverse_url, credential) as client:
+                    fno_token = await client.auth.acquire_token("https://myenv.operations.dynamics.com")
+        """
+        pair = await self._acquire_token(_build_default_scope(resource_url))
+        return pair.access_token

--- a/src/PowerPlatform/Dataverse/aio/data/_async_odata.py
+++ b/src/PowerPlatform/Dataverse/aio/data/_async_odata.py
@@ -61,7 +61,7 @@ class _AsyncODataClient(_AsyncFileUploadMixin, _AsyncRelationshipOperationsMixin
 
         Sets up authentication, base URL, configuration, and internal caches.
 
-        :param auth: Async authentication manager providing ``_acquire_token(scope)`` that returns an object with ``access_token``.
+        :param auth: Async authentication manager exposing awaitable ``acquire_token(resource_url)`` that returns the OAuth2 access token string for the given resource. ``_headers()`` awaits ``auth.acquire_token(self.base_url)`` so the token is scoped to this OData client's Dataverse organization.
         :type auth: ~PowerPlatform.Dataverse.aio.core._async_auth._AsyncAuthManager
         :param base_url: Organization base URL (e.g. ``"https://<org>.crm.dynamics.com"``).
         :type base_url: ``str``
@@ -96,8 +96,7 @@ class _AsyncODataClient(_AsyncFileUploadMixin, _AsyncRelationshipOperationsMixin
 
     async def _headers(self) -> Dict[str, str]:
         """Build standard OData headers with bearer auth."""
-        scope = f"{self.base_url}/.default"
-        token = (await self.auth._acquire_token(scope)).access_token
+        token = await self.auth.acquire_token(self.base_url)
         ua = f"{_USER_AGENT} ({self._operation_context})" if self._operation_context else _USER_AGENT
         return {
             "Authorization": f"Bearer {token}",

--- a/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
+++ b/src/PowerPlatform/Dataverse/claude_skill/dataverse-sdk-use/SKILL.md
@@ -79,6 +79,24 @@ with DataverseClient("https://yourorg.crm.dynamics.com", credential) as client:
 client = DataverseClient("https://yourorg.crm.dynamics.com", credential)
 ```
 
+### Acquiring Tokens for Other Microsoft Resources
+
+`client.auth.acquire_token(resource_url)` returns an OAuth2 access token from the **same credential** for any Microsoft Entra ID protected resource — for example a linked Dynamics 365 Finance & Operations environment. Use it instead of building a second credential. The `/.default` scope is appended automatically.
+
+```python
+# Sync client
+fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
+
+# Use the token to call the ERP OData / Custom Service endpoints directly
+headers = {"Authorization": f"Bearer {fno_token}"}
+
+# Async client
+async with AsyncDataverseClient("https://yourorg.crm.dynamics.com", credential) as aclient:
+    fno_token = await aclient.auth.acquire_token("https://myenv.operations.dynamics.com")
+```
+
+Pass the bare resource URL — trailing slashes and surrounding whitespace are trimmed, and a blank value raises `ValueError`. The app registration must already hold the required permission on the target resource with admin consent granted. For Finance & Operations the standard delegated permissions are `OData.FullAccess` and `CustomService.FullAccess` on the **Microsoft Dynamics ERP** API (`00000015-0000-0000-c000-000000000000`).
+
 ### CRUD Operations
 
 #### Create Records

--- a/src/PowerPlatform/Dataverse/core/_auth.py
+++ b/src/PowerPlatform/Dataverse/core/_auth.py
@@ -5,8 +5,10 @@
 Authentication helpers for Dataverse.
 
 This module provides :class:`~PowerPlatform.Dataverse.core._auth._AuthManager`, a thin wrapper over any Azure Identity
-``TokenCredential`` for acquiring OAuth2 access tokens, and :class:`~PowerPlatform.Dataverse.core._auth._TokenPair` for
-storing the acquired token alongside its scope.
+``TokenCredential`` for acquiring OAuth2 access tokens for Microsoft Entra ID protected resources -- Dataverse by
+default, and any other resource (for example a linked Dynamics 365 Finance & Operations environment) when a different
+resource URL is supplied -- and :class:`~PowerPlatform.Dataverse.core._auth._TokenPair` for storing the acquired token
+alongside its scope.
 """
 
 from __future__ import annotations
@@ -14,6 +16,28 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from azure.core.credentials import TokenCredential
+
+#: Scope suffix appended to a resource URL to request the resource's default (statically consented) permission set.
+_DEFAULT_SCOPE_SUFFIX = "/.default"
+
+
+def _build_default_scope(resource_url: str) -> str:
+    """
+    Build the ``<resource>/.default`` OAuth2 scope for a resource URL.
+
+    Shared by the sync and async auth managers so scope construction lives in exactly one place.
+
+    :param resource_url: Resource URL for the target Microsoft service (e.g. ``"https://<org>.crm.dynamics.com"``).
+        Surrounding whitespace and trailing slashes are removed before the suffix is appended.
+    :type resource_url: :class:`str`
+    :return: The ``/.default`` scope string for ``resource_url``.
+    :rtype: :class:`str`
+    :raises ValueError: If ``resource_url`` is empty, whitespace-only, or only slashes.
+    """
+    target = (resource_url or "").strip().rstrip("/")
+    if not target:
+        raise ValueError("resource_url must not be empty.")
+    return f"{target}{_DEFAULT_SCOPE_SUFFIX}"
 
 
 @dataclass(repr=False)
@@ -44,7 +68,12 @@ class _TokenPair:
 
 class _AuthManager:
     """
-    Azure Identity-based authentication manager for Dataverse.
+    Azure Identity-based authentication manager.
+
+    Resource-agnostic: the resource URL passed to :meth:`acquire_token` selects the target resource. The Dataverse
+    client supplies its own organization URL on every internal request, and the same method can be called by
+    application code (through ``client.auth.acquire_token(...)``) to obtain tokens for other Microsoft Entra ID
+    protected resources -- for example a linked Dynamics 365 Finance & Operations environment.
 
     :param credential: Azure Identity credential implementation.
     :type credential: ~azure.core.credentials.TokenCredential
@@ -68,3 +97,30 @@ class _AuthManager:
         """
         token = self.credential.get_token(scope)
         return _TokenPair(resource=scope, access_token=token.token)
+
+    def acquire_token(self, resource_url: str) -> str:
+        """
+        Acquire an OAuth2 access token for a Microsoft Entra ID protected resource.
+
+        Resource-agnostic helper: pass the resource URL (the Dataverse environment URL for Dataverse, the Finance &
+        Operations environment URL for ERP, and so on) and the ``/.default`` scope suffix is appended automatically
+        before delegating to the underlying credential. Token caching, refresh, and silent reauthentication remain the
+        credential's responsibility; Azure Identity credentials cache in memory by default, so repeated calls are cheap.
+
+        :param resource_url: Resource URL for the target Microsoft service (for example
+            ``"https://myenv.operations.dynamics.com"``). Surrounding whitespace and trailing slashes are removed
+            before scope construction.
+        :type resource_url: :class:`str`
+        :return: OAuth2 access token string suitable for an ``Authorization: Bearer <token>`` header.
+        :rtype: :class:`str`
+        :raises ValueError: If ``resource_url`` is empty after trimming whitespace and trailing slashes.
+        :raises ~azure.core.exceptions.ClientAuthenticationError: If token acquisition fails.
+
+        Example:
+            Acquire a token for a linked Finance & Operations environment using the same credential the Dataverse
+            client was built with::
+
+                client = DataverseClient(dataverse_url, credential)
+                fno_token = client.auth.acquire_token("https://myenv.operations.dynamics.com")
+        """
+        return self._acquire_token(_build_default_scope(resource_url)).access_token

--- a/src/PowerPlatform/Dataverse/data/_odata.py
+++ b/src/PowerPlatform/Dataverse/data/_odata.py
@@ -62,7 +62,7 @@ class _ODataClient(_FileUploadMixin, _RelationshipOperationsMixin, _ODataBase):
 
         Sets up authentication, base URL, configuration, and internal caches.
 
-        :param auth: Authentication manager providing ``_acquire_token(scope)`` that returns an object with ``access_token``.
+        :param auth: Authentication manager exposing ``acquire_token(resource_url)`` that returns the OAuth2 access token string for the given resource. ``_headers()`` calls ``auth.acquire_token(self.base_url)`` so the token is scoped to this OData client's Dataverse organization.
         :type auth: ~PowerPlatform.Dataverse.core._auth._AuthManager
         :param base_url: Organization base URL (e.g. ``"https://<org>.crm.dynamics.com"``).
         :type base_url: ``str``
@@ -94,8 +94,7 @@ class _ODataClient(_FileUploadMixin, _RelationshipOperationsMixin, _ODataBase):
 
     def _headers(self) -> Dict[str, str]:
         """Build standard OData headers with bearer auth."""
-        scope = f"{self.base_url}/.default"
-        token = self.auth._acquire_token(scope).access_token
+        token = self.auth.acquire_token(self.base_url)
         ua = _USER_AGENT
         if self._operation_context:
             ua = f"{_USER_AGENT} ({self._operation_context})"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,12 @@ from PowerPlatform.Dataverse.core.config import DataverseConfig
 
 @pytest.fixture
 def dummy_auth():
-    """Mock authentication object for testing."""
+    """Mock authentication object for testing.
+
+    Mirrors the real ``_AuthManager`` surface: both the internal
+    ``_acquire_token(scope)`` and the public ``acquire_token(resource_url)``
+    used by ``_ODataClient._headers()``.
+    """
 
     class DummyAuth:
         def _acquire_token(self, scope):
@@ -23,6 +28,9 @@ def dummy_auth():
                 access_token = "test_token_12345"
 
             return Token()
+
+        def acquire_token(self, resource_url):
+            return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
 
     return DummyAuth()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ that can be used across all test modules.
 
 import pytest
 from unittest.mock import Mock
+from PowerPlatform.Dataverse.core._auth import _build_default_scope
 from PowerPlatform.Dataverse.core.config import DataverseConfig
 
 
@@ -19,7 +20,9 @@ def dummy_auth():
 
     Mirrors the real ``_AuthManager`` surface: both the internal
     ``_acquire_token(scope)`` and the public ``acquire_token(resource_url)``
-    used by ``_ODataClient._headers()``.
+    used by ``_ODataClient._headers()``. Scope construction reuses the
+    production ``_build_default_scope`` helper so the double preserves its
+    normalization and ``ValueError`` validation instead of drifting from it.
     """
 
     class DummyAuth:
@@ -30,7 +33,7 @@ def dummy_auth():
             return Token()
 
         def acquire_token(self, resource_url):
-            return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+            return self._acquire_token(_build_default_scope(resource_url)).access_token
 
     return DummyAuth()
 

--- a/tests/unit/aio/core/test_async_auth.py
+++ b/tests/unit/aio/core/test_async_auth.py
@@ -47,3 +47,64 @@ class TestAsyncAuthManager:
         await manager._acquire_token("https://example.crm10.dynamics.com/.default")
 
         mock_cred.get_token.assert_called_once_with("https://example.crm10.dynamics.com/.default")
+
+
+class TestAsyncAuthManagerAcquireToken:
+    """Tests for the public, resource-agnostic ``_AsyncAuthManager.acquire_token``.
+
+    Mirrors ``tests/unit/core/test_auth.py::TestAuthManagerAcquireToken`` so the async
+    client keeps parity with the sync client for cross-resource token acquisition.
+    """
+
+    async def test_appends_default_scope_and_returns_token_string(self):
+        """acquire_token appends /.default to the resource URL and returns the access token string."""
+        mock_cred = MagicMock(spec=AsyncTokenCredential)
+        mock_cred.get_token = AsyncMock(return_value=MagicMock(token="dv-token"))
+
+        manager = _AsyncAuthManager(mock_cred)
+        result = await manager.acquire_token("https://org.crm.dynamics.com")
+
+        mock_cred.get_token.assert_called_once_with("https://org.crm.dynamics.com/.default")
+        assert result == "dv-token"
+
+    async def test_strips_trailing_slash(self):
+        """acquire_token strips trailing slashes before constructing the scope."""
+        mock_cred = MagicMock(spec=AsyncTokenCredential)
+        mock_cred.get_token = AsyncMock(return_value=MagicMock(token="t"))
+
+        manager = _AsyncAuthManager(mock_cred)
+        await manager.acquire_token("https://myenv.operations.dynamics.com/")
+
+        mock_cred.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+
+    async def test_strips_surrounding_whitespace(self):
+        """acquire_token trims whitespace so a padded URL still yields a well-formed scope."""
+        mock_cred = MagicMock(spec=AsyncTokenCredential)
+        mock_cred.get_token = AsyncMock(return_value=MagicMock(token="t"))
+
+        manager = _AsyncAuthManager(mock_cred)
+        await manager.acquire_token("  https://myenv.operations.dynamics.com/  ")
+
+        mock_cred.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+
+    async def test_supports_alternate_resource(self):
+        """acquire_token works for any resource URL (for example a linked Finance & Operations env)."""
+        mock_cred = MagicMock(spec=AsyncTokenCredential)
+        mock_cred.get_token = AsyncMock(return_value=MagicMock(token="fno-token"))
+
+        manager = _AsyncAuthManager(mock_cred)
+        result = await manager.acquire_token("https://myenv.operations.dynamics.com")
+
+        mock_cred.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+        assert result == "fno-token"
+
+    @pytest.mark.parametrize("bad", ["", "   ", "/", "  //  ", None])
+    async def test_blank_url_raises_without_calling_credential(self, bad):
+        """Blank input fails locally with ValueError instead of requesting a malformed scope."""
+        mock_cred = MagicMock(spec=AsyncTokenCredential)
+        mock_cred.get_token = AsyncMock()
+        manager = _AsyncAuthManager(mock_cred)
+
+        with pytest.raises(ValueError):
+            await manager.acquire_token(bad)
+        mock_cred.get_token.assert_not_called()

--- a/tests/unit/aio/data/test_async_odata_internal.py
+++ b/tests/unit/aio/data/test_async_odata_internal.py
@@ -22,6 +22,7 @@ def _make_client() -> _AsyncODataClient:
     """Return _AsyncODataClient with _request mocked out at the HTTP boundary."""
     auth = MagicMock()
     auth._acquire_token = AsyncMock(return_value=MagicMock(access_token="test-token"))
+    auth.acquire_token = AsyncMock(return_value="test-token")
     client = _AsyncODataClient(auth, "https://example.crm.dynamics.com")
     client._request = AsyncMock()
     return client
@@ -105,6 +106,7 @@ class TestRequest:
         """Return a client with a real auth mock but _raw_request not yet patched."""
         auth = MagicMock()
         auth._acquire_token = AsyncMock(return_value=MagicMock(access_token="token"))
+        auth.acquire_token = AsyncMock(return_value="token")
         return _AsyncODataClient(auth, "https://example.crm.dynamics.com")
 
     async def test_ok_response_returned(self):
@@ -1377,6 +1379,7 @@ class TestRequestMergeAndEdgeCases:
     def _auth_client(self):
         auth = MagicMock()
         auth._acquire_token = AsyncMock(return_value=MagicMock(access_token="token"))
+        auth.acquire_token = AsyncMock(return_value="token")
         return _AsyncODataClient(auth, "https://example.crm.dynamics.com")
 
     async def test_caller_headers_merged_with_base_headers(self):
@@ -1880,6 +1883,7 @@ class TestAsyncOperationContextUserAgent:
         config = DataverseConfig(operation_context=OperationContext(user_agent_context=ctx_str))
         auth = MagicMock()
         auth._acquire_token = AsyncMock(return_value=MagicMock(access_token="test-token"))
+        auth.acquire_token = AsyncMock(return_value="test-token")
         client = _AsyncODataClient(auth, "https://example.crm.dynamics.com", config=config)
         headers = await client._headers()
         assert headers["User-Agent"] == f"{_USER_AGENT} ({ctx_str})"
@@ -1890,6 +1894,53 @@ class TestAsyncOperationContextUserAgent:
         config = DataverseConfig(operation_context=None)
         auth = MagicMock()
         auth._acquire_token = AsyncMock(return_value=MagicMock(access_token="test-token"))
+        auth.acquire_token = AsyncMock(return_value="test-token")
         client = _AsyncODataClient(auth, "https://example.crm.dynamics.com", config=config)
         headers = await client._headers()
         assert "(" not in headers["User-Agent"]
+
+
+class TestAsyncODataClientHeadersAuthWiring:
+    """Regression tests for ``_AsyncODataClient._headers`` auth wiring.
+
+    Async counterpart of ``tests/unit/data/test_odata_internal.py::TestODataClientHeadersAuthWiring``.
+    Locks the contract that ``_headers()`` awaits the public, resource-agnostic
+    ``auth.acquire_token(base_url)`` entry point and places the returned token verbatim in the
+    ``Authorization`` header.
+    """
+
+    async def test_headers_calls_acquire_token_with_base_url(self):
+        """_headers passes the client's base_url (no /.default suffix) to auth.acquire_token."""
+        base_url = "https://example.crm.dynamics.com"
+        auth = MagicMock()
+        auth.acquire_token = AsyncMock(return_value="tok-abc")
+
+        client = _AsyncODataClient(auth, base_url)
+        await client._headers()
+
+        auth.acquire_token.assert_awaited_once_with(base_url)
+
+    async def test_headers_places_token_in_authorization_bearer(self):
+        """_headers uses the string returned by auth.acquire_token as the bearer token."""
+        auth = MagicMock()
+        auth.acquire_token = AsyncMock(return_value="tok-xyz")
+
+        client = _AsyncODataClient(auth, "https://example.crm.dynamics.com")
+        headers = await client._headers()
+
+        assert headers["Authorization"] == "Bearer tok-xyz"
+
+    async def test_headers_end_to_end_scope_through_real_async_auth_manager(self):
+        """A real _AsyncAuthManager wired into _headers requests the Dataverse /.default scope."""
+        from azure.core.credentials_async import AsyncTokenCredential
+
+        from PowerPlatform.Dataverse.aio.core._async_auth import _AsyncAuthManager
+
+        mock_cred = MagicMock(spec=AsyncTokenCredential)
+        mock_cred.get_token = AsyncMock(return_value=MagicMock(token="real-token"))
+
+        client = _AsyncODataClient(_AsyncAuthManager(mock_cred), "https://example.crm.dynamics.com")
+        headers = await client._headers()
+
+        mock_cred.get_token.assert_awaited_once_with("https://example.crm.dynamics.com/.default")
+        assert headers["Authorization"] == "Bearer real-token"

--- a/tests/unit/aio/data/test_async_relationships.py
+++ b/tests/unit/aio/data/test_async_relationships.py
@@ -25,6 +25,7 @@ def _make_client() -> _AsyncODataClient:
     """Return _AsyncODataClient with _request mocked at the HTTP boundary."""
     auth = MagicMock()
     auth._acquire_token = AsyncMock(return_value=MagicMock(access_token="token"))
+    auth.acquire_token = AsyncMock(return_value="token")
     client = _AsyncODataClient(auth, "https://example.crm.dynamics.com")
     client._request = AsyncMock()
     return client

--- a/tests/unit/aio/data/test_async_upload.py
+++ b/tests/unit/aio/data/test_async_upload.py
@@ -20,6 +20,7 @@ def _make_client() -> _AsyncODataClient:
     """Return _AsyncODataClient with _request mocked at the HTTP boundary."""
     auth = MagicMock()
     auth._acquire_token = AsyncMock(return_value=MagicMock(access_token="token"))
+    auth.acquire_token = AsyncMock(return_value="token")
     client = _AsyncODataClient(auth, "https://example.crm.dynamics.com")
     client._request = AsyncMock()
     return client

--- a/tests/unit/core/test_auth.py
+++ b/tests/unit/core/test_auth.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 from azure.core.credentials import TokenCredential
 
-from PowerPlatform.Dataverse.core._auth import _AuthManager, _TokenPair
+from PowerPlatform.Dataverse.core._auth import _AuthManager, _TokenPair, _build_default_scope
 
 
 class TestAuthManager(unittest.TestCase):
@@ -33,6 +33,83 @@ class TestAuthManager(unittest.TestCase):
         self.assertIsInstance(result, _TokenPair)
         self.assertEqual(result.resource, "https://org.crm.dynamics.com/.default")
         self.assertEqual(result.access_token, "my-access-token")
+
+
+class TestAuthManagerAcquireToken(unittest.TestCase):
+    """Tests for the public, resource-agnostic ``_AuthManager.acquire_token``."""
+
+    def test_appends_default_scope_and_returns_token_string(self):
+        """acquire_token appends /.default to the resource URL and returns the access token string."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="dv-token")
+
+        manager = _AuthManager(mock_credential)
+        result = manager.acquire_token("https://org.crm.dynamics.com")
+
+        mock_credential.get_token.assert_called_once_with("https://org.crm.dynamics.com/.default")
+        self.assertEqual(result, "dv-token")
+
+    def test_strips_trailing_slash(self):
+        """acquire_token strips trailing slashes before constructing the scope."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="t")
+
+        manager = _AuthManager(mock_credential)
+        manager.acquire_token("https://myenv.operations.dynamics.com/")
+
+        mock_credential.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+
+    def test_strips_surrounding_whitespace(self):
+        """acquire_token trims whitespace so a padded URL still yields a well-formed scope."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="t")
+
+        manager = _AuthManager(mock_credential)
+        manager.acquire_token("  https://myenv.operations.dynamics.com/  ")
+
+        mock_credential.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+
+    def test_supports_alternate_resource(self):
+        """acquire_token works for any resource URL (for example a linked Finance & Operations env)."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="fno-token")
+
+        manager = _AuthManager(mock_credential)
+        result = manager.acquire_token("https://myenv.operations.dynamics.com")
+
+        mock_credential.get_token.assert_called_once_with("https://myenv.operations.dynamics.com/.default")
+        self.assertEqual(result, "fno-token")
+
+    def test_blank_url_raises_without_calling_credential(self):
+        """Blank input fails locally with ValueError instead of requesting a malformed scope."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        manager = _AuthManager(mock_credential)
+
+        for bad in ("", "   ", "/", "  //  ", None):
+            with self.subTest(resource_url=bad):
+                with self.assertRaises(ValueError):
+                    manager.acquire_token(bad)
+        mock_credential.get_token.assert_not_called()
+
+
+class TestBuildDefaultScope(unittest.TestCase):
+    """Scope construction is shared by the sync and async auth managers."""
+
+    def test_appends_suffix(self):
+        self.assertEqual(
+            _build_default_scope("https://org.crm.dynamics.com"),
+            "https://org.crm.dynamics.com/.default",
+        )
+
+    def test_normalizes_whitespace_and_trailing_slashes(self):
+        self.assertEqual(
+            _build_default_scope("  https://org.crm.dynamics.com//  "),
+            "https://org.crm.dynamics.com/.default",
+        )
+
+    def test_blank_raises(self):
+        with self.assertRaises(ValueError):
+            _build_default_scope("   ")
 
 
 class TestTokenPairReprRedaction(unittest.TestCase):

--- a/tests/unit/core/test_auth.py
+++ b/tests/unit/core/test_auth.py
@@ -4,6 +4,7 @@
 import unittest
 from unittest.mock import MagicMock
 
+import pytest
 from azure.core.credentials import TokenCredential
 
 from PowerPlatform.Dataverse.core._auth import _AuthManager, _TokenPair, _build_default_scope
@@ -207,3 +208,20 @@ class TestTokenPairReprRedaction(unittest.TestCase):
         pair = manager._acquire_token("https://org.crm.dynamics.com/.default")
         self.assertNotIn(self.JWT, repr(pair))
         self.assertIn("[REDACTED]", repr(pair))
+
+
+class TestSharedDummyAuthFixtureContract:
+    """The shared ``dummy_auth`` test double must not drift from the real ``_AuthManager``.
+
+    It reuses :func:`_build_default_scope`, so the double inherits the production
+    normalization and ``ValueError`` validation instead of silently minting a token
+    for a malformed ``/.default`` scope.
+    """
+
+    def test_returns_token_for_valid_resource(self, dummy_auth):
+        assert dummy_auth.acquire_token("https://org.crm.dynamics.com") == "test_token_12345"
+
+    @pytest.mark.parametrize("bad", ["", "   ", "/", "  //  ", None])
+    def test_blank_resource_raises_value_error(self, dummy_auth, bad):
+        with pytest.raises(ValueError):
+            dummy_auth.acquire_token(bad)

--- a/tests/unit/core/test_http_errors.py
+++ b/tests/unit/core/test_http_errors.py
@@ -17,6 +17,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):
+        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+
 
 class DummyHTTP:
     def __init__(self, responses):

--- a/tests/unit/core/test_http_errors.py
+++ b/tests/unit/core/test_http_errors.py
@@ -7,6 +7,7 @@ from PowerPlatform.Dataverse.client import DataverseClient
 from PowerPlatform.Dataverse.core.config import DataverseConfig
 from PowerPlatform.Dataverse.core.errors import HttpError
 from PowerPlatform.Dataverse.core._error_codes import HTTP_404, HTTP_429, HTTP_500
+from PowerPlatform.Dataverse.core._auth import _build_default_scope
 from PowerPlatform.Dataverse.data._odata import _ODataClient
 
 
@@ -18,7 +19,7 @@ class DummyAuth:
         return T()
 
     def acquire_token(self, resource_url):
-        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+        return self._acquire_token(_build_default_scope(resource_url)).access_token
 
 
 class DummyHTTP:

--- a/tests/unit/data/test_batch_edge_cases.py
+++ b/tests/unit/data/test_batch_edge_cases.py
@@ -1044,6 +1044,7 @@ class TestRobustnessEdgeCases(unittest.TestCase):
 
         mock_auth = MagicMock()
         mock_auth._acquire_token.return_value = MagicMock(access_token="token")
+        mock_auth.acquire_token.return_value = "token"
         od = _ODataClient(mock_auth, "https://example.crm.dynamics.com")
 
         # _escape_odata_quotes doubles single quotes

--- a/tests/unit/data/test_enum_optionset_payload.py
+++ b/tests/unit/data/test_enum_optionset_payload.py
@@ -4,6 +4,7 @@
 import pytest
 from enum import Enum, IntEnum
 
+from PowerPlatform.Dataverse.core._auth import _build_default_scope
 from PowerPlatform.Dataverse.data._odata import _ODataClient
 
 
@@ -15,7 +16,7 @@ class DummyAuth:
         return T()
 
     def acquire_token(self, resource_url):  # pragma: no cover - simple stub
-        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+        return self._acquire_token(_build_default_scope(resource_url)).access_token
 
 
 class DummyConfig:

--- a/tests/unit/data/test_enum_optionset_payload.py
+++ b/tests/unit/data/test_enum_optionset_payload.py
@@ -14,6 +14,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):  # pragma: no cover - simple stub
+        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+
 
 class DummyConfig:
     """Minimal config stub providing attributes _ODataClient.__init__ expects."""

--- a/tests/unit/data/test_logical_crud.py
+++ b/tests/unit/data/test_logical_crud.py
@@ -14,6 +14,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):
+        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+
 
 class DummyHTTPClient:
     def __init__(self, responses):

--- a/tests/unit/data/test_logical_crud.py
+++ b/tests/unit/data/test_logical_crud.py
@@ -4,6 +4,7 @@
 import types
 import pytest
 from PowerPlatform.Dataverse.data._odata import _ODataClient
+from PowerPlatform.Dataverse.core._auth import _build_default_scope
 from PowerPlatform.Dataverse.core.errors import MetadataError
 
 
@@ -15,7 +16,7 @@ class DummyAuth:
         return T()
 
     def acquire_token(self, resource_url):
-        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+        return self._acquire_token(_build_default_scope(resource_url)).access_token
 
 
 class DummyHTTPClient:

--- a/tests/unit/data/test_odata_internal.py
+++ b/tests/unit/data/test_odata_internal.py
@@ -7,6 +7,9 @@ import unittest
 from enum import Enum
 from unittest.mock import MagicMock, patch
 
+from azure.core.credentials import TokenCredential
+
+from PowerPlatform.Dataverse.core._auth import _AuthManager
 from PowerPlatform.Dataverse.core.errors import HttpError, MetadataError, ValidationError
 from PowerPlatform.Dataverse.data._odata import _ODataClient
 
@@ -15,6 +18,7 @@ def _make_odata_client() -> _ODataClient:
     """Return an _ODataClient with HTTP calls mocked out."""
     mock_auth = MagicMock()
     mock_auth._acquire_token.return_value = MagicMock(access_token="token")
+    mock_auth.acquire_token.return_value = "token"
     client = _ODataClient(mock_auth, "https://example.crm.dynamics.com")
     client._request = MagicMock()
     return client
@@ -602,6 +606,7 @@ class TestRequestErrorParsing(unittest.TestCase):
     def setUp(self):
         mock_auth = MagicMock()
         mock_auth._acquire_token.return_value = MagicMock(access_token="token")
+        mock_auth.acquire_token.return_value = "token"
         self.client = _ODataClient(mock_auth, "https://example.crm.dynamics.com")
 
     def _make_raw_response(self, status_code, json_data=None, headers=None):
@@ -3067,6 +3072,48 @@ class TestBuildCreateEntity(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             self.od._build_create_entity("new_TestTable", {"new_Bad": "unsupported_type"})
+
+
+class TestODataClientHeadersAuthWiring(unittest.TestCase):
+    """Regression tests for ``_ODataClient._headers`` auth wiring.
+
+    Locks the contract that ``_headers()`` delegates token acquisition to the public,
+    resource-agnostic ``auth.acquire_token(base_url)`` entry point and places the returned
+    token verbatim in the ``Authorization`` header. Guards against a future refactor
+    silently reverting to inline scope construction or routing through a different scope.
+    """
+
+    def test_headers_calls_acquire_token_with_base_url(self):
+        """_headers passes the client's base_url (no /.default suffix) to auth.acquire_token."""
+        base_url = "https://example.crm.dynamics.com"
+        mock_auth = MagicMock()
+        mock_auth.acquire_token.return_value = "tok-abc"
+
+        client = _ODataClient(mock_auth, base_url)
+        client._headers()
+
+        mock_auth.acquire_token.assert_called_once_with(base_url)
+
+    def test_headers_places_token_in_authorization_bearer(self):
+        """_headers uses the string returned by auth.acquire_token as the bearer token."""
+        mock_auth = MagicMock()
+        mock_auth.acquire_token.return_value = "tok-xyz"
+
+        client = _ODataClient(mock_auth, "https://example.crm.dynamics.com")
+        headers = client._headers()
+
+        self.assertEqual(headers["Authorization"], "Bearer tok-xyz")
+
+    def test_headers_end_to_end_scope_through_real_auth_manager(self):
+        """A real _AuthManager wired into _headers requests the Dataverse /.default scope."""
+        mock_credential = MagicMock(spec=TokenCredential)
+        mock_credential.get_token.return_value = MagicMock(token="real-token")
+
+        client = _ODataClient(_AuthManager(mock_credential), "https://example.crm.dynamics.com")
+        headers = client._headers()
+
+        mock_credential.get_token.assert_called_once_with("https://example.crm.dynamics.com/.default")
+        self.assertEqual(headers["Authorization"], "Bearer real-token")
 
 
 if __name__ == "__main__":

--- a/tests/unit/data/test_sql_guardrails.py
+++ b/tests/unit/data/test_sql_guardrails.py
@@ -20,6 +20,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):
+        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+
 
 def _client():
     return _ODataClient(DummyAuth(), "https://org.example", None)

--- a/tests/unit/data/test_sql_guardrails.py
+++ b/tests/unit/data/test_sql_guardrails.py
@@ -9,6 +9,7 @@ import pytest
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
+from PowerPlatform.Dataverse.core._auth import _build_default_scope
 from PowerPlatform.Dataverse.core.errors import ValidationError
 from PowerPlatform.Dataverse.data._odata import _ODataClient
 
@@ -21,7 +22,7 @@ class DummyAuth:
         return T()
 
     def acquire_token(self, resource_url):
-        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+        return self._acquire_token(_build_default_scope(resource_url)).access_token
 
 
 def _client():

--- a/tests/unit/data/test_sql_parse.py
+++ b/tests/unit/data/test_sql_parse.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from PowerPlatform.Dataverse.core._auth import _build_default_scope
 from PowerPlatform.Dataverse.data._odata import _ODataClient, _extract_pagingcookie
 
 
@@ -16,7 +17,7 @@ class DummyAuth:
         return T()
 
     def acquire_token(self, resource_url):
-        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+        return self._acquire_token(_build_default_scope(resource_url)).access_token
 
 
 def _client():

--- a/tests/unit/data/test_sql_parse.py
+++ b/tests/unit/data/test_sql_parse.py
@@ -15,6 +15,9 @@ class DummyAuth:
 
         return T()
 
+    def acquire_token(self, resource_url):
+        return self._acquire_token(f"{(resource_url or '').strip().rstrip('/')}/.default").access_token
+
 
 def _client():
     return _ODataClient(DummyAuth(), "https://org.example", None)

--- a/tests/unit/data/test_upload.py
+++ b/tests/unit/data/test_upload.py
@@ -13,6 +13,7 @@ def _make_odata_client() -> _ODataClient:
     """Return an _ODataClient with HTTP calls mocked out."""
     mock_auth = MagicMock()
     mock_auth._acquire_token.return_value = MagicMock(access_token="token")
+    mock_auth.acquire_token.return_value = "token"
     client = _ODataClient(mock_auth, "https://example.crm.dynamics.com")
     client._request = MagicMock()
     return client

--- a/tests/unit/test_operation_context.py
+++ b/tests/unit/test_operation_context.py
@@ -144,6 +144,7 @@ class TestOperationContextUserAgent(unittest.TestCase):
         token_result = MagicMock()
         token_result.access_token = "test-token"
         self.dummy_auth._acquire_token.return_value = token_result
+        self.dummy_auth.acquire_token.return_value = "test-token"
         self.base_url = "https://org.example.com"
 
     def test_default_user_agent_unchanged(self):


### PR DESCRIPTION
Adds a public, resource-agnostic token helper so callers can reuse the credential the Dataverse client was constructed with to reach other Microsoft Entra ID protected resources -- most commonly a linked Dynamics 365 Finance & Operations environment sitting alongside the same Dataverse org -- without building and consenting a second credential.

- `_AuthManager.acquire_token(resource_url) -> str` (sync)
- `_AsyncAuthManager.acquire_token(resource_url) -> str` (async, awaitable)

Both append the `/.default` scope suffix via a single shared `_build_default_scope()` helper, which trims surrounding whitespace and trailing slashes and raises `ValueError` on blank input so malformed scopes fail locally instead of at the token endpoint.

`_ODataClient._headers()` and `_AsyncODataClient._headers()` now route through the same public method, removing the duplicated inline scope construction. Constructor docstrings for both OData clients were updated to document the new `acquire_token(resource_url)` auth contract, and the shared/local auth test doubles were updated to match.

Supersedes #182: rebased onto current main (1.0.1), adds the async client parity requested in review, plus whitespace-trim validation, `_headers()` regression tests for both clients, and `OData.FullAccess` casing in docs.