### PR TITLE
Fix displaycollectionname pluralization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `DisplayCollectionName` now uses correct English pluralization when creating tables
+  (e.g. `"Category"` → `"Categories"`, `"Person"` → `"People"`) instead of naive `+ "s"` (#166).
+
+### Changed
+
+- Added `inflect>=7.0` as a dependency to power correct English pluralization of table display names.
+
 ## [1.0.0] - 2026-05-28
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `DisplayCollectionName` now uses correct English pluralization when creating tables
   (e.g. `"Category"` → `"Categories"`, `"Person"` → `"People"`) instead of naive `+ "s"` (#166).
+- Pluralization of `DisplayCollectionName` no longer collapses the casing of PascalCase
+  display names (e.g. `"SalesOrder"` → `"SalesOrders"` instead of `"Salesorders"`), and a
+  `display_name` with surrounding whitespace (e.g. `"Product "`) is trimmed before use
+  instead of being sent un-pluralized and padded (#166).
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "azure-core>=1.30.2",
     "requests>=2.32.0",
     "pandas>=2.0.0",
+    "inflect>=7.0",
 ]
 
 [project.urls]

--- a/src/PowerPlatform/Dataverse/aio/data/_async_odata.py
+++ b/src/PowerPlatform/Dataverse/aio/data/_async_odata.py
@@ -44,6 +44,7 @@ from ...data._odata_base import (
     _USER_AGENT,
     _DEFAULT_EXPECTED_STATUSES,
     _RequestContext,
+    _pluralize,
 )
 
 
@@ -852,7 +853,7 @@ class _AsyncODataClient(_AsyncFileUploadMixin, _AsyncRelationshipOperationsMixin
                     "@odata.type": "Microsoft.Dynamics.CRM.ComplexEntityMetadata",
                     "SchemaName": table_schema_name,
                     "DisplayName": self._label(display_name),
-                    "DisplayCollectionName": self._label(display_name + "s"),
+                    "DisplayCollectionName": self._label(_pluralize(display_name)),
                     "Description": self._label(f"Custom entity for {display_name}"),
                     "OwnershipType": "UserOwned",
                     "HasActivities": False,

--- a/src/PowerPlatform/Dataverse/data/_odata.py
+++ b/src/PowerPlatform/Dataverse/data/_odata.py
@@ -45,6 +45,7 @@ from ._odata_base import (
     _USER_AGENT,
     _DEFAULT_EXPECTED_STATUSES,
     _RequestContext,
+    _pluralize,
 )
 
 
@@ -831,7 +832,7 @@ class _ODataClient(_FileUploadMixin, _RelationshipOperationsMixin, _ODataBase):
                     "@odata.type": "Microsoft.Dynamics.CRM.ComplexEntityMetadata",
                     "SchemaName": table_schema_name,
                     "DisplayName": self._label(display_name),
-                    "DisplayCollectionName": self._label(display_name + "s"),
+                    "DisplayCollectionName": self._label(_pluralize(display_name)),
                     "Description": self._label(f"Custom entity for {display_name}"),
                     "OwnershipType": "UserOwned",
                     "HasActivities": False,

--- a/src/PowerPlatform/Dataverse/data/_odata_base.py
+++ b/src/PowerPlatform/Dataverse/data/_odata_base.py
@@ -633,6 +633,7 @@ class _ODataBase:
         if display_name is not None:
             if not isinstance(display_name, str) or not display_name.strip():
                 raise TypeError("display_name must be a non-empty string when provided")
+            display_name = display_name.strip()
         label = display_name if display_name is not None else table
         body = {
             "Entities": [

--- a/src/PowerPlatform/Dataverse/data/_odata_base.py
+++ b/src/PowerPlatform/Dataverse/data/_odata_base.py
@@ -49,12 +49,26 @@ _inflect = inflect.engine()
 
 
 def _inflect_word(word: str) -> str:
-    """Pluralize a single word via inflect, preserving leading capitalisation."""
+    """Pluralize a single word via inflect, preserving the original casing.
+
+    ``inflect`` only applies its full pluralization rules (e.g. ``y`` -> ``ies``)
+    to lowercase input, so the word is lowercased before pluralizing. The
+    result is then spliced onto the original (cased) word at the point where
+    the lowercase singular and plural diverge, so casing internal to the word
+    (e.g. PascalCase like ``TestTable`` -> ``TestTables``) is preserved rather
+    than collapsed by re-capitalizing only the first letter.
+    """
     if not word:
         return word
-    is_title = word[0].isupper()
-    plural = _inflect.plural(word.lower())
-    return (plural[0].upper() + plural[1:]) if is_title and plural else plural
+    lower = word.lower()
+    plural_lower = _inflect.plural(lower)
+    if not plural_lower:
+        return word
+    common_len = 0
+    max_common = min(len(word), len(plural_lower))
+    while common_len < max_common and lower[common_len] == plural_lower[common_len]:
+        common_len += 1
+    return word[:common_len] + plural_lower[common_len:]
 
 
 def _pluralize(display_name: str) -> str:

--- a/src/PowerPlatform/Dataverse/data/_odata_base.py
+++ b/src/PowerPlatform/Dataverse/data/_odata_base.py
@@ -9,7 +9,6 @@ URL construction, payload building, cache helpers, and other stateless logic.
 
 from __future__ import annotations
 
-import inflect
 import json
 import re
 import unicodedata
@@ -21,6 +20,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import parse_qs, urlparse
+
+import inflect
 
 from .. import __version__ as _SDK_VERSION
 

--- a/src/PowerPlatform/Dataverse/data/_odata_base.py
+++ b/src/PowerPlatform/Dataverse/data/_odata_base.py
@@ -9,6 +9,7 @@ URL construction, payload building, cache helpers, and other stateless logic.
 
 from __future__ import annotations
 
+import inflect
 import json
 import re
 import unicodedata
@@ -42,6 +43,37 @@ from ._raw_request import _RawRequest
 __all__ = []
 
 _GUID_RE = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
+
+_inflect = inflect.engine()
+
+
+def _inflect_word(word: str) -> str:
+    """Pluralize a single word via inflect, preserving leading capitalisation."""
+    if not word:
+        return word
+    is_title = word[0].isupper()
+    plural = _inflect.plural(word.lower())
+    return (plural[0].upper() + plural[1:]) if is_title and plural else plural
+
+
+def _pluralize(display_name: str) -> str:
+    """Pluralize the last word of a Dataverse display name for use as DisplayCollectionName.
+
+    Handles publisher-prefixed tokens (e.g. ``"new_Category"`` → ``"new_Categories"``)
+    and multi-word names (e.g. ``"My Category"`` → ``"My Categories"``).
+    """
+    if not display_name:
+        return display_name
+    parts = display_name.split(" ")
+    last = parts[-1]
+    if "_" in last:
+        prefix, _, tail = last.rpartition("_")
+        parts[-1] = f"{prefix}_{_inflect_word(tail)}" if tail else last
+    else:
+        parts[-1] = _inflect_word(last)
+    return " ".join(parts)
+
+
 _CALL_SCOPE_CORRELATION_ID: ContextVar[Optional[str]] = ContextVar("_CALL_SCOPE_CORRELATION_ID", default=None)
 _USER_AGENT = f"DataverseSvcPythonClient:{_SDK_VERSION}"
 _DEFAULT_EXPECTED_STATUSES: tuple[int, ...] = (200, 201, 202, 204)
@@ -593,7 +625,7 @@ class _ODataBase:
                     "@odata.type": "Microsoft.Dynamics.CRM.ComplexEntityMetadata",
                     "SchemaName": table,
                     "DisplayName": self._label(label),
-                    "DisplayCollectionName": self._label(label + "s"),
+                    "DisplayCollectionName": self._label(_pluralize(label)),
                     "Description": self._label(f"Custom entity for {label}"),
                     "OwnershipType": "UserOwned",
                     "HasActivities": False,

--- a/tests/unit/aio/data/test_async_odata_internal.py
+++ b/tests/unit/aio/data/test_async_odata_internal.py
@@ -1938,3 +1938,13 @@ class TestAsyncCreateTableDisplayCollectionName:
         self._setup_for_create(client)
         await client._create_table("new_Status", {}, display_name="Status")
         assert self._collection_label(client) == "Statuses"
+
+    async def test_default_display_name_preserves_pascal_case_when_pluralized(self):
+        """Regression test: when display_name is omitted, it defaults to
+        table_schema_name, and pluralizing it must not collapse internal
+        PascalCase (e.g. "new_TestTable" -> "new_TestTables", not
+        "new_Testtables")."""
+        client = _make_client()
+        self._setup_for_create(client)
+        await client._create_table("new_TestTable", {})
+        assert self._collection_label(client) == "new_TestTables"

--- a/tests/unit/aio/data/test_async_odata_internal.py
+++ b/tests/unit/aio/data/test_async_odata_internal.py
@@ -1893,3 +1893,48 @@ class TestAsyncOperationContextUserAgent:
         client = _AsyncODataClient(auth, "https://example.crm.dynamics.com", config=config)
         headers = await client._headers()
         assert "(" not in headers["User-Agent"]
+
+
+@pytest.mark.asyncio
+class TestAsyncCreateTableDisplayCollectionName:
+    """Verify async _create_table generates correct DisplayCollectionName via _pluralize."""
+
+    def _setup_for_create(self, client):
+        created = {
+            "MetadataId": "meta-001",
+            "EntitySetName": "new_categories",
+            "LogicalName": "new_category",
+            "SchemaName": "new_Category",
+            "PrimaryNameAttribute": "new_name",
+            "PrimaryIdAttribute": "new_categoryid",
+        }
+        call_count = [0]
+
+        async def mock_get_entity(table_schema_name, headers=None):
+            call_count[0] += 1
+            return None if call_count[0] == 1 else created
+
+        client._get_entity_by_table_schema_name = AsyncMock(side_effect=mock_get_entity)
+        client._request = AsyncMock(return_value=_resp(json_data={}))
+
+    def _collection_label(self, client):
+        post_json = client._request.call_args.kwargs["json"]
+        return post_json["Entities"][0]["DisplayCollectionName"]["LocalizedLabels"][0]["Label"]
+
+    async def test_category_pluralized_correctly(self):
+        client = _make_client()
+        self._setup_for_create(client)
+        await client._create_table("new_Category", {}, display_name="Category")
+        assert self._collection_label(client) == "Categories"
+
+    async def test_person_pluralized_correctly(self):
+        client = _make_client()
+        self._setup_for_create(client)
+        await client._create_table("new_Person", {}, display_name="Person")
+        assert self._collection_label(client) == "People"
+
+    async def test_status_pluralized_correctly(self):
+        client = _make_client()
+        self._setup_for_create(client)
+        await client._create_table("new_Status", {}, display_name="Status")
+        assert self._collection_label(client) == "Statuses"

--- a/tests/unit/data/test_odata_internal.py
+++ b/tests/unit/data/test_odata_internal.py
@@ -2967,6 +2967,15 @@ class TestBuildCreateEntity(unittest.TestCase):
         body = self._body(display_name="Test Table")
         self.assertEqual(body["DisplayCollectionName"]["LocalizedLabels"][0]["Label"], "Test Tables")
 
+    def test_display_name_surrounding_whitespace_stripped(self):
+        """Regression test: a trailing/leading space in display_name must not
+        leave DisplayName/DisplayCollectionName unpluralized or padded, e.g.
+        "Product " should behave exactly like "Product", not send "Product "
+        as DisplayName and leave DisplayCollectionName un-pluralized."""
+        body = self._body(display_name="Product ")
+        self.assertEqual(body["DisplayName"]["LocalizedLabels"][0]["Label"], "Product")
+        self.assertEqual(body["DisplayCollectionName"]["LocalizedLabels"][0]["Label"], "Products")
+
     def test_display_name_empty_string_raises(self):
         """_build_create_entity raises TypeError when display_name is an empty string."""
         with self.assertRaises(TypeError):

--- a/tests/unit/data/test_odata_internal.py
+++ b/tests/unit/data/test_odata_internal.py
@@ -2963,7 +2963,7 @@ class TestBuildCreateEntity(unittest.TestCase):
         self.assertEqual(body["DisplayName"]["LocalizedLabels"][0]["Label"], "new_TestTable")
 
     def test_display_collection_name_derived_from_display_name(self):
-        """_build_create_entity appends 's' to display_name for DisplayCollectionName."""
+        """_build_create_entity pluralizes display_name for DisplayCollectionName."""
         body = self._body(display_name="Test Table")
         self.assertEqual(body["DisplayCollectionName"]["LocalizedLabels"][0]["Label"], "Test Tables")
 
@@ -3067,6 +3067,94 @@ class TestBuildCreateEntity(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             self.od._build_create_entity("new_TestTable", {"new_Bad": "unsupported_type"})
+
+
+class TestPluralize(unittest.TestCase):
+    """Unit tests for the _pluralize / _inflect_word helpers."""
+
+    def setUp(self):
+        from PowerPlatform.Dataverse.data._odata_base import _pluralize
+        self._p = _pluralize
+
+    def test_regular_word(self):
+        self.assertEqual(self._p("Product"), "Products")
+
+    def test_consonant_y_ending(self):
+        self.assertEqual(self._p("Category"), "Categories")
+
+    def test_s_ending(self):
+        self.assertEqual(self._p("Status"), "Statuses")
+
+    def test_irregular_person(self):
+        self.assertEqual(self._p("Person"), "People")
+
+    def test_irregular_child(self):
+        self.assertEqual(self._p("Child"), "Children")
+
+    def test_publisher_prefix(self):
+        self.assertEqual(self._p("new_Category"), "new_Categories")
+
+    def test_publisher_prefix_irregular(self):
+        self.assertEqual(self._p("new_Person"), "new_People")
+
+    def test_multiword(self):
+        self.assertEqual(self._p("My Category"), "My Categories")
+
+    def test_empty_string(self):
+        self.assertEqual(self._p(""), "")
+
+    def test_lowercase_preserved(self):
+        self.assertEqual(self._p("category"), "categories")
+
+
+class TestCreateTableDisplayCollectionName(unittest.TestCase):
+    """Verify _create_table generates correct DisplayCollectionName via _pluralize."""
+
+    def _setup_for_create(self, od):
+        created = {
+            "MetadataId": "meta-001",
+            "EntitySetName": "new_categories",
+            "LogicalName": "new_category",
+            "SchemaName": "new_Category",
+            "PrimaryNameAttribute": "new_name",
+            "PrimaryIdAttribute": "new_categoryid",
+        }
+        call_count = [0]
+
+        def mock_get_entity(table_schema_name, headers=None):
+            call_count[0] += 1
+            return None if call_count[0] == 1 else created
+
+        od._get_entity_by_table_schema_name = MagicMock(side_effect=mock_get_entity)
+        od._request = MagicMock(return_value=MagicMock(status_code=200, json=lambda: {}))
+
+    def _collection_label(self, od):
+        post_json = od._request.call_args.kwargs["json"]
+        return post_json["Entities"][0]["DisplayCollectionName"]["LocalizedLabels"][0]["Label"]
+
+    def test_category_pluralized_correctly(self):
+        od = _make_odata_client()
+        self._setup_for_create(od)
+        od._create_table("new_Category", {}, display_name="Category")
+        self.assertEqual(self._collection_label(od), "Categories")
+
+    def test_person_pluralized_correctly(self):
+        od = _make_odata_client()
+        self._setup_for_create(od)
+        od._create_table("new_Person", {}, display_name="Person")
+        self.assertEqual(self._collection_label(od), "People")
+
+    def test_status_pluralized_correctly(self):
+        od = _make_odata_client()
+        self._setup_for_create(od)
+        od._create_table("new_Status", {}, display_name="Status")
+        self.assertEqual(self._collection_label(od), "Statuses")
+
+    def test_prefixed_display_name_pluralized_correctly(self):
+        od = _make_odata_client()
+        self._setup_for_create(od)
+        od._create_table("new_Category", {}, display_name="new_Category")
+        self.assertEqual(self._collection_label(od), "new_Categories")
 
 
 if __name__ == "__main__":

--- a/tests/unit/data/test_odata_internal.py
+++ b/tests/unit/data/test_odata_internal.py
@@ -3106,6 +3106,15 @@ class TestPluralize(unittest.TestCase):
     def test_lowercase_preserved(self):
         self.assertEqual(self._p("category"), "categories")
 
+    def test_pascal_case_internal_casing_preserved(self):
+        self.assertEqual(self._p("TestTable"), "TestTables")
+
+    def test_pascal_case_irregular_word_boundary(self):
+        self.assertEqual(self._p("SalesOrder"), "SalesOrders")
+
+    def test_pascal_case_publisher_prefix(self):
+        self.assertEqual(self._p("new_TestTable"), "new_TestTables")
+
 
 class TestCreateTableDisplayCollectionName(unittest.TestCase):
     """Verify _create_table generates correct DisplayCollectionName via _pluralize."""
@@ -3155,6 +3164,16 @@ class TestCreateTableDisplayCollectionName(unittest.TestCase):
         self._setup_for_create(od)
         od._create_table("new_Category", {}, display_name="new_Category")
         self.assertEqual(self._collection_label(od), "new_Categories")
+
+    def test_default_display_name_preserves_pascal_case_when_pluralized(self):
+        """Regression test: when display_name is omitted, it defaults to
+        table_schema_name, and pluralizing it must not collapse internal
+        PascalCase (e.g. "new_TestTable" -> "new_TestTables", not
+        "new_Testtables")."""
+        od = _make_odata_client()
+        self._setup_for_create(od)
+        od._create_table("new_TestTable", {})
+        self.assertEqual(self._collection_label(od), "new_TestTables")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Replace display_name + "s" with an inflect based pluralization (`_pluralize` / `_inflect_word` in `_odata_base.py`
- Applied it at all payload building sites (`_create_entity`, async `_create_entity`, `_build_create_entity`)
- Added inflect>=7.0 dependency